### PR TITLE
Add a python-interface section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # generated output
 out/*
+__pycache__/

--- a/python-interface/README.md
+++ b/python-interface/README.md
@@ -1,0 +1,647 @@
+# Python interfacing methods and data representation model
+
+This section provides Python components to represent the data model of the BLE advertisements produced by the custom firmware, as well as a documented interface and a testing tool to receive, decode, show and edit the BLE advertisements delivered via the custom firmware.
+
+The base components used here are:
+
+- [bleak](https://bleak.readthedocs.io/en/latest/), a cross-platform BLE library;
+- [construct](https://construct.readthedocs.io/en/latest/intro.html), a symmetric Python library allowing to declaratively define a data structure that describes the advertisement frames produced by the custom firmware.
+- [construct-gallery](https://github.com/Ircama/construct-gallery), a set of tools extending [construct-editor](https://github.com/timrid/construct-editor/), which provides a GUI (based on [wxPython](https://www.wxpython.org/)) for *construct*. All these tools are used here, including plugins and [bleak_scanner_construct.py](bleak_scanner_construct.py), a library to browse BLE advertisements.
+
+The software in this section includes:
+
+- a [*construct* data model](construct_atc_mi.py) representing the *custom*, *atc1441*, *mi_like* and *bt_home* formats, respectively in clear and encrypted structures.
+- a [Python module to normalize *bleak* frames](atc_mi_adv_format.py) so that they can be directly processed by the *construct* library.
+- an easy to use [BLE Advertisement Browser GUI](atc_mi_advertising.py) based on the [wxPython](https://www.wxpython.org/) cross-platform desktop GUI toolkit, including controls on the BLE advertisements, map MAC addresses, bindkeys, etc.
+
+![Preview](images/ble_browser.gif)
+
+This GUI exploits the [construct_gallery](https://github.com/Ircama/construct-gallery) library, that extends the [Construct Editor](https://github.com/timrid/construct-editor/) library underneath.
+
+## Decoding and encoding
+
+The [construct_atc_mi.py](construct_atc_mi.py) module allows managing all data formats, including parsing frames to variables, building frames from variables, encrypting and decrypting using related keys and more. It relies on [construct_atc_mi_adapters.py](construct_atc_mi_adapters.py) that implements the custom adapters used by *construct_atc_mi.py*.
+
+Parsing a [*custom* frame](https://github.com/pvvx/ATC_MiThermometer#custom-format-all-data-little-endian):
+
+```python
+from construct_atc_mi import general_format
+print(general_format.parse(bytes.fromhex(
+    '12 16 1a 18 5c c8 ee 38 c1 a4 b0 08 c3 14 ca 0a 50 14 05')))
+```
+
+Output:
+
+```python
+Container:
+    version = 1
+    custom_enc_format = ListContainer:
+    custom_format = ListContainer:
+        Container:
+            version = 1
+            size = 18
+            uid = 22
+            UUID = b'\x18\x1a' (total 2)
+            MAC = u'A4:C1:38:EE:C8:5C' (total 17)
+            mac_vendor = u'Telink Semiconductor' (total 20)
+            temperature = 22.24
+            temperature_unit = u'°C' (total 2)
+            humidity = 53.15
+            humidity_unit = u'%' (total 1)
+            battery_v = 2.762
+            battery_v_unit = u'V' (total 1)
+            battery_level = 80
+            battery_level_unit = u'%' (total 1)
+            counter = 20
+            flags = Container:
+                humidity_trigger = False
+                temp_trigger = False
+                out_gpio_trg_flag = True
+                out_gpio_trg_value = False
+                input_gpio_value = True
+    atc1441_enc_format = ListContainer:
+    atc1441_format = ListContainer:
+    mi_like_format = ListContainer:
+    bt_home_format = ListContainer:
+    bt_home_enc_format = ListContainer:
+```
+
+Parsing any type of format (*custom*, *atc1441*, *mi_like*, *bt_home*, either they are encrypted or not), automatically selected basing on the frame:
+
+```python
+from construct_atc_mi import general_format
+
+frame1 = bytes.fromhex('12 16 1a 18 cc bb aa 38 c1 a4 77 07 88 13 ca 0a 50 01 07')
+
+atc_mi_data = general_format.parse(frame1)
+
+print("temperature:", atc_mi_data.search_all("^temperature"))
+print("humidity:", atc_mi_data.search_all("^humidity"))
+print("battery_level:", atc_mi_data.search_all("^battery_level"))
+print("battery_v:", atc_mi_data.search_all("^battery_v"))
+
+print()
+
+frame2 = bytes.fromhex('16 16 1e 18 ec 12 cf e5 00 00 3a f3 95 3c a0 5a 7d 03 00 2a ea f8 ea')
+bindkey = bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+mac_address = bytes.fromhex("A4:C1:38:AA:BB:CC".replace(':', ''))
+
+atc_mi_data = general_format.parse(frame2, bindkey=bindkey, mac_address=mac_address)
+
+print("temperature:", atc_mi_data.search_all("^temperature"))
+print("humidity:", atc_mi_data.search_all("^humidity"))
+print("battery_level:", atc_mi_data.search_all("^battery_level"))
+print("battery_v:", atc_mi_data.search_all("^battery_v"))
+```
+
+Output:
+
+```python
+temperature: [19.11, '°C']
+humidity: [50.0, '%', False]
+battery_level: [80, '%']
+battery_v: [2.762, 'V']
+
+temperature: [20.0, '°C']
+humidity: [50.0, '%']
+battery_level: [100, '%']
+battery_v: []
+```
+
+Alternatively to `general_format`, also `custom_format` can be used to decode *frame1* and `bt_home_enc_format` to decode *frame2* (after importing them).
+
+Building the frame with the reverse process:
+
+```python
+from construct_atc_mi import custom_format
+
+custom_format.build(
+    {
+        "size": 18,
+        "uid": 22,
+        "UUID": b"\x18\x1a",
+        "MAC": "A4:C1:38:AA:BB:CC",
+        "temperature": 19.11,
+        "humidity": 50.0,
+        "battery_v": 2.762,
+        "battery_level": 80,
+        "counter": 1,
+        "flags": {
+            "humidity_trigger": False,
+            "temp_trigger": False,
+            "out_gpio_trg_flag": True,
+            "out_gpio_trg_value": True,
+            "input_gpio_value": True,
+        },
+    }
+).hex(' ')
+```
+
+Output:
+
+```
+'12 16 1a 18 cc bb aa 38 c1 a4 77 07 88 13 ca 0a 50 01 07'
+```
+
+## Encrypting and decrypting
+
+All encoded versions of the structures (*custom_enc_format*, *atc1441_enc_format*, *bt_home_enc_format* and *mi_like_format* with encryption flag) support the following additional parameters:
+
+- `mac_address`: MAC address in bytes (e.g., `bytes.fromhex("A4:C1:38:AA:BB:CC".replace(":", ""))`)
+- `bindkey`: Bindkey in bytes (e.g., `bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")`)
+
+Alternatively (but not suggested), if the same MAC address and key are needed for all queries of a specific parser, the same parameters can be put in *construct_atc_mi.py* within the related `"codec"` adapter, like with the following:
+
+```python
+...
+    "codec" / AtcMiCodec(
+        Aligned(11,
+            Struct(
+                ...
+            )
+        ),
+        size_payload=6,
+        mac_address=bytes.fromhex("A4:C1:38:AA:BB:CC".replace(":", "")),
+        bindkey=bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+    ),
+)
+```
+
+Parsing example with `general_format`, that also includes encrypted formats like `custom_enc_format`:
+
+```python
+from construct_atc_mi import general_format
+
+print(
+    general_format.parse(
+        bytes.fromhex("0e 16 1a 18 bd 9d c5 4e fa b5 00 0e 8b b8 07"),
+        mac_address=bytes.fromhex("A4:C1:38:AA:BB:CC".replace(":", "")),
+        bindkey=bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    )
+)
+```
+    
+Output:
+
+```python
+Container:
+    version = 1
+    custom_enc_format = ListContainer:
+        Container:
+            version = 1
+            size = 14
+            uid = 22
+            UUID = b'\x18\x1a' (total 2)
+            codec = Container:
+                temperature = 19.11
+                temperature_unit = u'°C' (total 2)
+                humidity = 50.0
+                humidity_unit = u'%' (total 1)
+                battery_level = 93
+                battery_level_unit = u'%' (total 1)
+                flags = Container:
+                    humidity_trigger = False
+                    temp_trigger = True
+                    out_gpio_trg_flag = True
+                    out_gpio_trg_value = True
+                    input_gpio_value = True
+    custom_format = ListContainer:
+    atc1441_enc_format = ListContainer:
+    atc1441_format = ListContainer:
+    mi_like_format = ListContainer:
+    bt_home_format = ListContainer:
+    bt_home_enc_format = ListContainer:
+```
+
+Building the frame with the reverse process:
+
+```python
+from construct_atc_mi import custom_enc_format
+
+custom_enc_format.build(
+    {
+        "size": 14,
+        "uid": 22,
+        "UUID": b"\x18\x1a",
+        "codec": {
+            "temperature": 19.11,
+            "humidity": 50.0,
+            "battery_level": 80,
+            "counter": 1,
+            "flags": {
+                "humidity_trigger": False,
+                "temp_trigger": False,
+                "out_gpio_trg_flag": True,
+                "out_gpio_trg_value": True,
+                "input_gpio_value": True,
+            }
+        }
+    },
+    mac_address=bytes.fromhex("A4:C1:38:AA:BB:CC".replace(":", "")),
+    bindkey=bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+).hex(' ')
+```
+
+Output:
+
+```
+'0e 16 1a 18 bd 9d c5 4e fa b8 08 56 6b e8 7f'
+```
+
+For the build process, generally `Container` is mapped to a dictionary (`{ ... }`), `ListContainer` to a list (`[ ... ]`) and `(enum)` with a normal `key: value` inside a dictionary (with the strings in quotes).
+
+Another parsing example with `bt_home_enc_format`:
+
+```python
+from construct_atc_mi import bt_home_enc_format
+
+print(
+    bt_home_enc_format.parse(
+        bytes.fromhex("16 16 1e 18 23 1b 90 11 7c cd e0 4b a1 73 26 5c 7d 03 00 68 8c 9b 84"),
+        mac_address=bytes.fromhex("A4:C1:38:AA:BB:CC".replace(":", "")),
+        bindkey=bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    )
+)
+```
+
+Output:
+
+```python
+Container:
+    version = 1
+    size = 22
+    uid = 22
+    UUID = b'\x18\x1e' (total 2)
+    codec = Container:
+        count_id = 228700
+        payload = ListContainer:
+            Container:
+                bt_home_type = (enum) BT_HOME_temperature 8962
+                data = Container:
+                    temperature = 19.11
+                    temperature_unit = u'°C' (total 2)
+            Container:
+                bt_home_type = (enum) BT_HOME_humidity 771
+                data = Container:
+                    humidity = 50.0
+                    humidity_unit = u'%' (total 1)
+            Container:
+                bt_home_type = (enum) BT_HOME_battery 513
+                data = Container:
+                    battery_level = 80
+                    battery_level_unit = u'%' (total 1)
+```
+
+Reverse process:
+
+```python
+from construct_atc_mi import bt_home_enc_format
+
+bt_home_enc_format.build(
+    {
+        "size": 22,
+        "uid": 22,
+        "UUID": b"\x18\x1e",
+        "codec": {
+            "count_id": 228700,
+            "payload": [
+                {
+                    "bt_home_type": "BT_HOME_temperature",
+                    "data": {"temperature": 19.11},
+                },
+                {
+                    "bt_home_type": "BT_HOME_humidity",
+                    "data": {"humidity": 50.0},
+                },
+                {
+                    "bt_home_type": "BT_HOME_battery",
+                    "data": {"battery_level": 80},
+                }
+            ]
+        }
+    },
+    mac_address=bytes.fromhex("A4:C1:38:AA:BB:CC".replace(":", "")),
+    bindkey=bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+).hex(" ")
+```
+
+Output:
+
+```
+'16 16 1e 18 23 1b 90 11 7c cd e0 4b a1 73 26 5c 7d 03 00 68 8c 9b 84'
+```
+
+# Processing BLE advertisements
+
+The simplest program to process BLE advertisements produced by the thermometers is the following one:
+
+```python
+import asyncio
+from bleak import BleakScanner
+from functools import partial
+from construct_atc_mi import general_format
+from atc_mi_adv_format import atc_mi_advertising_format
+
+bindkey = {
+    "A4:C1:38:AA:BB:CC": bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    "A4:C1:38:AA:BB:00": bytes.fromhex("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+    # ...
+}
+
+async def main():
+    count = [0]
+    stop_event = asyncio.Event()
+
+    def detection_callback(count, device, advertisement_data):
+        format_label, adv_data = atc_mi_advertising_format(advertisement_data)
+        if not adv_data:
+            return
+        mac_address = bytes.fromhex(device.address.replace(":", ""))
+        atc_mi_data = general_format.parse(
+            adv_data,
+            mac_address=mac_address,
+            bindkey=bindkey[mac_address] if mac_address in bindkey else None
+        )
+        print(f"{count[0]}. {format_label} advertisement: {atc_mi_data}. "
+            f"RSSI: {device.rssi}")
+        count[0] += 1
+        if count[0] == 5:
+            stop_event.set()
+
+    async with BleakScanner(
+        detection_callback=partial(detection_callback, count)
+    ) as scanner:
+        await stop_event.wait()
+    print("Stopped")
+
+
+asyncio.run(main())
+```
+
+The program prints the first 5 parsed frames from available thermometers, regardless their configurations. It exploits `atc_mi_advertising_format()`, which adds headers to the BLE advertisements produced by the thermometers and discovered by `BleakScanner()` (from *bleak*), so that the resulting frame can be directly processed by the *construct* structures included in `construct_atc_mi`.
+
+## BLE Advertisement Browser GUI
+
+[atc_mi_advertising.py](atc_mi_advertising.py) is a Python GUI performing BLE advertisement analysis of data transmitted by thermometers, data editing and testing.
+
+Before running it, it is important to install prerequisites with the following command:
+
+```bash
+# Install prerequisites:
+pip3 install -r requirements.txt
+```
+
+To run the program:
+
+```bash
+# run program:
+python3 atc_mi_advertising.py
+```
+
+Program command line options:
+
+```
+usage: atc_mi_advertising.py [-h] [-s] [-m] [-l LOG_DATA_FILE [LOG_DATA_FILE ...]] [-i]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -s, --start           start BLE
+  -m, --maximized       display the frame maximized
+  -l LOG_DATA_FILE [LOG_DATA_FILE ...], --load LOG_DATA_FILE [LOG_DATA_FILE ...]
+                        log data file(s) to be automatically loaded at startup.
+  -i, --inspectable     enable Inspection
+
+Xiaomi Mijia Thermometer - BLE Advertisement Browser
+```
+
+Main functionalities.
+- BLE client to log, browse, test and edit advertisements produced by the Xiaomi Mijia Thermometers
+- Cross-platform GUI
+- The GUI includes a BLE control (implemented with buttons) which allows starting and stopping the BLE advertisement receiver. Advertisements are logged in their reception sequence, automatically labbelled basing on the discovered format and including related MAC address, so that they can be immediately selected by the user to browse and parse data.
+- A filter button can be used to enter a specific MAC address to restrict logging, a portion of it or a sequence of addresses, as well as BLE local names.
+- Logged data can be saved to file in [pickle format](https://docs.python.org/3/library/pickle.html). Archives can be subsequently reloaded and appended to the current log. They can also be inspected with `python -mpickle archive-file-name.pickle`.
+- Advertisement data are logged in the left panel, shown as hex bytes in the central panel and then parsed to browsable *construct* structures in the right panel.
+- The program uses `construct_atc_mi.py` to parse and build data and a special button allows dynamic reloading of this module, so that it can be easily edited, tested and tuned for new features.
+- Everything is GUI based. Also the Python error management is wrapped into a GUI panel.
+- A Python shell button allows opening an inspector shell, which also provides a special *Help* with related submenu (or by pressing F9).
+- All panels allow a context menu (invoked with the right click of the mouse) with a number of special functions.
+  - The left log menu panel allows renaming labels and changing MAC address, as well as its related bindkey and description. Also, by double clicking an unused area of the log panel, new frames can be added and then labelled; subsequently, a specific MAC address can be associated. For each MAC address the related bindkey and description can be edited. Log elements can be repositioned, or deleted.
+  - The hex editor (central panel) allows any kind of copy/paste. Sequences of bytes can be pasted [in a number of different formats](https://github.com/timrid/construct-editor/pull/17#issuecomment-1367582581). Also a special checkbox enables pasting Python expressions. Two debugging tools are also provided (invoked with the right click of the mouse after selecting a sequence of bytes), to convert bytes into a wide set of numeric forms as well as strings; these debug panels can be used to quickly check the most appropriate conversion method for a sequence of bytes.
+  - The construct right panel is also enriched by a right-click context menu controlling a number of features. Notice for instance the possibility to show hidden values, which are by default disabled.
+- Encryption and decryprion are fully supported and a separate central panel in the lowest part of the screen shows the bytes produced by the related codec, mapping them with the referred structure in the right panel.
+- The right panel allows changing all values (apart from the "Computed" ones) by double clicking the shown values, so that a new sequence of bytes is automatically built (including encryption when needed).
+- A button shows a table allowing to edit MAC addresses and their related Bindkey and description.
+- The program has command line arguments and one allows loading a saved log at startup; another option automatically starts the BLE advertisement receiver.
+- When starting the BLE reception, a debug window is opened in background, with the possibility to control the debug level and clear the produced data.
+- The `-i` command line option is for [debugging](https://wiki.wxpython.org/How%20to%20use%20Widget%20Inspection%20Tool%20-%20WIT%20%28Phoenix%29), which can be activated with Ctrl-Alt-I, or Cmd-Alt-I on Mac.
+
+To check all available formats, run the following:
+
+The stand-alone sample program [test_atc_formats.py](test_atc_formats.py) allows browsing all available formats, with samples. It consists of a very simple source code, which sets the *gallery_descriptor* variable and then calls *ConstructGallery* passing appropriate parameters. For instance, after running this program, included sample data can be saved to *all-formats.pickle* and then loaded with *atc_mi_advertising.py* via:
+
+```bash
+python3 atc_mi_advertising.py -m -l all-formats.pickle
+```
+
+### atc_mi_advertising.py
+
+Technically, *atc_mi_advertising.py* is a very small and basic wrapper of the separate *construct_gallery* Python module, which does all the logic underneath. In turn, *construct_gallery*  relies on [construct-editor](https://github.com/timrid/construct-editor), a very powerful, well-designed and extensible module which implements all the construct editor widgets.
+
+```mermaid
+classDiagram
+    Main --> AtcMiConstructFrame
+    AtcMiConstructFrame --|> wxFrame
+    AtcMiConstructFrame --> AtcMiBleakScannerConstruct
+    AtcMiBleakScannerConstruct --|> BleakScannerConstruct 
+
+    class AtcMiConstructFrame{
+        maximized
+        loadfile
+        ble_start
+
+        **kwargs
+        __init__()
+        on_close()
+    }
+
+    class AtcMiBleakScannerConstruct{
+        ble_start
+        gallery_descriptor
+
+        filter_hint_mac="A4:C1:38"
+        filter_hint_name="LYWSD03MMC, ATC"
+        key_label="Bindkey"
+        description_label="Description"
+        col_name_width=200
+        col_type_width=150
+        __init__()
+        bleak_advertising()
+    }
+```
+
+### construct-gallery module
+
+```mermaid
+classDiagram
+    BleakScannerConstruct --|> ConstructGallery
+    ConstructGallery --> WxConstructHexEditor
+
+    class BleakScannerConstruct{
+        filter_hint_mac
+        filter_hint_name
+
+        reference_label="MAC address"
+        load_menu_label="Log Data and Configuration"
+        clear_label="Log Data"
+        added_data_label="Logging data"
+        logging_plugin=True
+    }
+
+    class ConstructGallery{
+        parent
+
+        load_menu_label="Gallery Data"
+        clear_label="Gallery"
+        reference_label=None
+        key_label=None
+        description_label=None
+        added_data_label=""
+        loadfile=None
+        gallery_descriptor=None
+        ordered_samples=None
+        ref_key_descriptor=None
+        default_gallery_selection=0
+        col_name_width=None
+        col_type_width=None
+        col_value_width=None
+        run_shell_plugin=True
+        run_hex_editor_plugins=True
+    }
+```
+
+### construct-editor module
+
+```mermaid
+classDiagram
+    WxConstructHexEditor --|> wxPanel
+
+    class WxConstructHexEditor{
+        parent
+        construct
+        contextkw
+        binary
+    }
+
+note   "...
+        ...
+        ..."
+```
+
+## Connecting to a LYWSD03MMC thermometer via BLE
+
+A simple program that connects to a LYWSD03MMC thermometer with native firmware and reads the parameters is the following:
+
+```python
+from bleak import BleakClient  # pip3 install bleak
+from construct_atc_mi import native_temp_hum_v_values, native_comfort_values
+import asyncio
+
+mac_address = "A4:C1:38:AA:BB:CC"
+valid_string_characteristics = [2, 13, 15, 17, 19, 21, 23, 95]
+valid_bytes_characteristics = [26, 30, 33, 34, 36, 37, 57]
+native_temp_hum_v_char = 53
+native_comfort_char = 66
+
+async def main(address):
+    for times in range(20):
+        try:
+            async with BleakClient(address, timeout=60.0) as client:
+                for service in client.services:
+                    for char in service.characteristics:
+                        name_bytes = await client.read_gatt_char(char)
+                        if char.handle in valid_bytes_characteristics:
+                            print(char.handle, service.description, "-", char.description, "- Value:", name_bytes.hex(' '))
+                        if char.handle in valid_string_characteristics:
+                            print(char.handle, service.description, "-", char.description, ":", name_bytes.decode())
+                        if char.handle == native_temp_hum_v_char:
+                            print(char.handle, char.description, ":", native_temp_hum_v_values.parse(name_bytes))
+                        if char.handle == native_comfort_char:
+                            print(char.handle, char.description, ":", native_comfort_values.parse(name_bytes))
+                break
+        except Exception as e:
+            print(f"Retrying... ({e})")
+
+asyncio.run(main(mac_address))
+```
+
+To run this program, flashing the custom firmware is not needed. Also, it does not rely on advertisements and performs a BLE connection (which discarges the battery). The address must be changed withe the actual MAC address.
+
+With native LYWSD03MMC firmware, its output is:
+
+```python
+2 Generic Access Profile - Device Name : LYWSD03MMC
+13 Device Information - Model Number String : LYWSD03MMC
+15 Device Information - Serial Number String : ...
+17 Device Information - Firmware Revision String : 1.0.0_0130
+19 Device Information - Hardware Revision String : B1.7
+21 Device Information - Software Revision String : 0130
+23 Device Information - Manufacturer Name String : miaomiaoce.com
+26 Battery Service - Battery Level - Value: 63
+30 Unknown - OTA - Value: 00
+34 Unknown - Time - Value: 9c 45 09 00
+37 Unknown - Data Count - Value: a7 00 00 00 a8 00 00 00
+53 Temperature and Humidity : Container:
+    version = 1
+    temperature = 19.1
+    temperature_unit = u'°C' (total 2)
+    humidity = 47
+    humidity_unit = u'%' (total 1)
+    battery_v = 2.983
+    battery_v_unit = u'V' (total 1)
+57 Unknown - Batt - Value: 64
+66 comfortable temp and humi : Container:
+    version = 1
+    temperature_high = 27.0
+    temperature_low = 19.0
+    humidity_high = 85
+    humidity_low = 20
+    humidity_unit = u'%' (total 1)
+95 Xiaomi Inc. - Version : 1.0.0_0130
+```
+
+In this simple program, some numeric values are not parsed.
+
+With the custom firmware v4.1, its output is:
+
+```python
+2 Generic Access Profile - Device Name : ATC_AABBCC
+13 Device Information - Model Number String : LYWSD03MMC
+15 Device Information - Serial Number String : ...
+17 Device Information - Firmware Revision String : github.com/pvvx
+19 Device Information - Hardware Revision String : B1.7
+21 Device Information - Software Revision String : V4.1
+23 Device Information - Manufacturer Name String : miaomiaoce.com
+26 Battery Service - Battery Level - Value: 64
+30 Environmental Sensing - Temperature Celsius - Value: bf 00
+33 Environmental Sensing - Temperature - Value: 76 07
+36 Environmental Sensing - Humidity - Value: 76 11
+```
+
+In this simple program, the "Environmental Sensing" values are not parsed.
+
+A more extensive program is [get_characteristics.py](get_characteristics.py), which parses all values.
+
+```
+Usage: python3 get_characteristics.py [-h] [-e] [-v] -m ADDRESS [-a ATTEMPTS]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -e, --error           show error information
+  -v, --verbosity       print process information
+  -m ADDRESS, --mac ADDRESS
+                        MAC Address
+  -a ATTEMPTS, --attempts ATTEMPTS
+                        max number of attempts (default=20)
+
+Xiaomi Mijia Thermometer - List BLE Characteristics
+```

--- a/python-interface/atc_mi_adv_format.py
+++ b/python-interface/atc_mi_adv_format.py
@@ -1,0 +1,54 @@
+gatt_dict = {
+    "atc1441": {
+        "gatt": '0000181a-0000-1000-8000-00805f9b34fb',  # Environmental Sensing
+        "length": 13,
+        "header": bytes.fromhex("161a18"),
+    },
+    "custom": {
+        "gatt": '0000181a-0000-1000-8000-00805f9b34fb',
+        "length": 15,
+        "header": bytes.fromhex("161a18"),
+    },
+    "custom_enc": {
+        "gatt": '0000181a-0000-1000-8000-00805f9b34fb',
+        "length": 11,
+        "header": bytes.fromhex("161a18"),
+    },
+    "atc1441_enc": {
+        "gatt": '0000181a-0000-1000-8000-00805f9b34fb',
+        "length": 8,
+        "header": bytes.fromhex("161a18"),
+    },
+    "mi_like": {
+        "gatt": '0000fe95-0000-1000-8000-00805f9b34fb',  # Xiaomi Inc.
+        "length": None,
+        "header": bytes.fromhex("1695fe"),
+    },
+    "bt_home": {
+        "gatt": '0000181c-0000-1000-8000-00805f9b34fb',  # SERVICE_UUID_USER_DATA, HA_BLE, no security
+        "length": None,
+        "header": bytes.fromhex("161c18"),
+    },
+    "bt_home_enc": {
+        "gatt": '0000181e-0000-1000-8000-00805f9b34fb',
+        "length": None,
+        "header": bytes.fromhex("161e18"),
+    }
+}
+
+def atc_mi_advertising_format(advertisement_data):
+    if not advertisement_data.service_data:
+        return "", ""
+    invalid_length = None
+    for t in gatt_dict.keys():
+        gatt_d = gatt_dict[t]
+        if gatt_d["gatt"] in advertisement_data.service_data:
+            payload = advertisement_data.service_data[gatt_d["gatt"]]
+            if gatt_d["length"] and len(payload) != gatt_d["length"]:
+                invalid_length = len(payload)
+                continue
+            header = gatt_d["header"]
+            return t, bytes([len(header) + len(payload)]) + header + payload
+    if invalid_length is not None:
+        return "Unknown-length-" + str(invalid_length), ""
+    return "Unknown", ""

--- a/python-interface/atc_mi_advertising.py
+++ b/python-interface/atc_mi_advertising.py
@@ -1,0 +1,128 @@
+import wx
+from wx.lib.embeddedimage import PyEmbeddedImage
+import logging
+from construct_gallery import BleakScannerConstruct
+import argparse
+
+from atc_mi_adv_format import atc_mi_advertising_format
+import construct_module
+import construct_atc_mi
+
+
+class AtcMiConstructFrame(wx.Frame):
+
+    icon_image = PyEmbeddedImage(
+        "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABHNCSVQICAgIfAhkiAAAAHFJ"
+        "REFUWIXt1jsKgDAQRdF7xY25cpcWC60kioI6Fm/ahHBCMh+BRmGMnAgEWnvPpzK8dvrFCCCA"
+        "coD8og4c5Lr6WB3Q3l1TBwLYPuF3YS1gn1HphgEEEABcKERrGy0E3B0HFJg7C1N/f/kTBBBA"
+        "+Vi+AMkgFEvBPD17AAAAAElFTkSuQmCC")
+
+    wx_log = None
+
+    def __init__(
+            self,
+            *args,
+            maximized=False,
+            loadfile=None,
+            ble_start=False,
+            **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.SetTitle("Xiaomi Mijia Thermometer - BLE Advertisement Browser")
+        self.SetSize(1000, 600)
+        self.SetIcon(self.icon_image.GetIcon())
+        self.Center()
+
+        self.status_bar: wx.StatusBar = self.CreateStatusBar()
+        self.main_panel = AtcMiBleakScannerConstruct(
+            self,
+            filter_hint_mac="A4:C1:38",
+            filter_hint_name="LYWSD03MMC, ATC",
+            key_label="Bindkey",
+            description_label="Description",
+            loadfile=loadfile,
+            ble_start=ble_start,
+            gallery_descriptor=construct_module,
+            col_name_width=200,
+            col_type_width=150)
+        self.Bind(wx.EVT_CLOSE, self.on_close)
+        if maximized:
+            self.Maximize(True)
+
+    def on_close(self, event):
+        self.main_panel.on_application_close()
+        event.Skip()
+
+
+class AtcMiBleakScannerConstruct(BleakScannerConstruct):
+    def __init__(self, *args, ble_start=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        if ble_start:
+            self.ble_start()
+
+    def bleak_advertising(self, device, advertisement_data):
+        format_label, adv_data = atc_mi_advertising_format(advertisement_data)
+        if "Unknown" in format_label:
+            logging.warning(
+                "mac: %s. %s advertisement: %s. RSSI: %s",
+                device.address, format_label, advertisement_data, device.rssi)
+            return
+        if adv_data:
+            self.add_data(
+                data=adv_data,
+                reference=device.address,
+                append_label=format_label
+            )
+        logging.info(
+            "mac: %s. %s advertisement: %s. RSSI: %s",
+            device.address, format_label, advertisement_data, device.rssi)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        epilog='Xiaomi Mijia Thermometer - BLE Advertisement Browser')
+    parser.add_argument(
+        '-s',
+        "--start",
+        dest='ble_start',
+        action='store_true',
+        help="start BLE")
+    parser.add_argument(
+        '-m',
+        "--maximized",
+        dest='maximized',
+        action='store_true',
+        help="display the frame maximized")
+    parser.add_argument(
+        '-l',
+        "--load",
+        dest='log_data_file',
+        type=argparse.FileType('rb'),
+        help="log data file(s) to be automatically loaded at startup.",
+        default=0,
+        nargs='+',
+        metavar='LOG_DATA_FILE')
+    parser.add_argument(
+        '-i',
+        "--inspectable",
+        dest='inspectable',
+        action='store_true',
+        help="enable Inspection")
+    args = parser.parse_args()
+    loadfile = None
+    if args.log_data_file:
+        loadfile = args.log_data_file
+    inspect = False
+    if args.inspectable:
+        import wx.lib.mixins.inspection as wit
+        app = wit.InspectableApp()
+    else:
+        wit = None
+        app = wx.App(False)
+    frame = AtcMiConstructFrame(None, maximized=args.maximized,
+        loadfile=loadfile, ble_start=args.ble_start)
+    frame.Show(True)
+    app.MainLoop()
+
+if __name__ == "__main__":
+    main()

--- a/python-interface/construct_atc_mi.py
+++ b/python-interface/construct_atc_mi.py
@@ -1,0 +1,383 @@
+from construct_atc_mi_adapters import *
+
+# -------------- custom_format -------------------------------------------------
+# "PVVX (Custom)" advertising type, encrypted beacon unchecked
+
+# https://github.com/pvvx/ATC_MiThermometer#custom-format-all-data-little-endian
+# Min. firmware Version: 0.8
+
+atc_flag = BitStruct(  # GPIO_TRG pin (marking "reset" on circuit board) flags:
+    Padding(3),
+    "humidity_trigger" / Flag,  # Bit 4 - Humidity trigger event
+    "temp_trigger" / Flag,  # Bit 3 - Temperature trigger event
+    "out_gpio_trg_flag" / Flag,  # Bit 2 - If this flag is set, the output GPIO_TRG pin is controlled according to the set parameters threshold temperature or humidity
+    "out_gpio_trg_value" / Flag,  # Bit 1 - GPIO_TRG pin output value (pull Up/Down)
+    "input_gpio_value" / Flag,  # Bit 0 - Reed Switch, input
+)
+
+custom_format = Struct(
+    "version" / Computed(1),
+    "size" / Int8ul,  # 18 (0x12)
+    "uid" / Int8ul,  # 22 (0x16, 16-bit UUID)
+    "UUID" / ByteSwapped(Const(b"\x18\x1a")),  # GATT Service 0x181A Environmental Sensing
+    "MAC" / ReversedMacAddress,  # [0] - lo, .. [6] - hi digits
+    "mac_vendor" / MacVendor,
+    "temperature" / Int16sl_x100,
+    "temperature_unit" / Computed("°C"),
+    "humidity" / Int16ul_x100,
+    "humidity_unit" / Computed("%"),
+    "battery_v" / Int16ul_x1000,
+    "battery_v_unit" / Computed("V"),
+    "battery_level" / Int8ul,  # 0..100 %
+    "battery_level_unit" / Computed("%"),
+    "counter" / Int8ul,  # measurement count
+    "flags" / atc_flag
+)
+
+# -------------- custom_enc_format ---------------------------------------------
+# "PVVX (Custom)" advertising type, encrypted beacon checked
+
+custom_enc_format = Struct(
+    "version" / Computed(1),
+    "size" / Int8ul,  # 14 (0x0e)
+    "uid" / Int8ul,  # 22 (0x16, 16-bit UUID)
+    "UUID" / ByteSwapped(Const(b"\x18\x1a")),  # GATT Service 0x181A Environmental Sensing
+    "codec" / AtcMiCodec(
+        Aligned(11,
+            Struct(
+                "temperature" / Int16sl_x100,
+                "temperature_unit" / Computed("°C"),
+                "humidity" / Int16ul_x100,
+                "humidity_unit" / Computed("%"),
+                "battery_level" / Int8ul,  # 0..100 %
+                "battery_level_unit" / Computed("%"),
+                "flags" / atc_flag
+            )
+        ),
+        size_payload=6,
+    ),
+)
+
+# -------------- atc1441_format ------------------------------------------------
+# "ATC1441" advertising type, encrypted beacon unchecked
+
+# https://github.com/pvvx/ATC_MiThermometer#atc1441-format
+
+atc1441_format = Struct(
+    "version" / Computed(1),
+    "size" / Int8ul,  # 18
+    "uid" / Int8ul,  # 0x16, 16-bit UUID
+    "UUID" / ByteSwapped(Const(b"\x18\x1a")),  # GATT Service 0x181A Environmental Sensing
+    "MAC" / MacAddress,  # [0] - hi, .. [6] - lo digits
+    "mac_vendor" / MacVendor,
+    "temperature" / Int16sb_x10,
+    "temperature_unit" / Computed("°C"),
+    "humidity" / Int8ul,  # 0..100 %
+    "humidity_unit" / Computed("%"),
+    "battery_level" / Int8ul,  # 0..100 %
+    "battery_level_unit" / Computed("%"),
+    "battery_v" / Int16ub_x1000,
+    "battery_v_unit" / Computed("V"),
+    "counter" / Int8ub  # frame packet counter
+)
+
+# -------------- atc1441_enc_format ------------------------------------------------
+# "ATC1441" advertising type, encrypted beacon checked
+
+# encrypted custom beacon
+# https://github.com/pvvx/ATC_MiThermometer/issues/94#issuecomment-842846036
+
+atc1441_enc_format = Struct(
+    "version" / Computed(1),
+    "size" / Int8ul,  # 14 (0x0e)
+    "uid" / Int8ul,  # 22 (0x16, 16-bit UUID)
+    "UUID" / ByteSwapped(Const(b"\x18\x1a")),  # GATT Service 0x181A Environmental Sensing
+    "codec" / AtcMiCodec(
+        Aligned(8,
+            Struct(
+                "temperature" / ExprAdapter(Int8sl,  # -40...87 °C with half degree precision
+                    obj_ / 2 - 40, lambda obj, ctx: int((float(obj) + 40) * 2)),
+                "temperature_unit" / Computed("°C"),
+                "humidity" / ExprAdapter(Int8ul,  # half unit precision
+                    obj_ / 2, lambda obj, ctx: int(float(obj) * 2)),
+                "humidity_unit" / Computed("%"),
+                "batt_trg" / BitStruct(
+                    "out_gpio_trg_flag" / Flag,  # If this flag is set, the output GPIO_TRG pin is controlled according to the set parameters threshold temperature or humidity
+                    "battery_level" / BitsInteger(7),  # 0..100 %
+                    "battery_level_unit" / Computed("%"),
+                )
+            )
+        ),
+        size_payload=3,
+    ),
+)
+
+# -------------- mi_like_format ------------------------------------------------
+# "MIJIA (MiHome)" advertising type, encrypted beacon either checked or unchecked
+
+# Can be clear or encrypted
+# https://github.com/pvvx/ATC_MiThermometer/tree/master/InfoMijiaBLE
+
+mi_like_data = Struct(  # https://github.com/pvvx/ATC_MiThermometer/blob/master/src/mi_beacon.h#L72-L97
+    "type" / Enum(Int16ul,
+        XIAOMI_DATA_ID_Sleep                =0x1002,
+        XIAOMI_DATA_ID_RSSI                 =0x1003,
+        XIAOMI_DATA_ID_Temperature          =0x1004,
+        XIAOMI_DATA_ID_Humidity             =0x1006,
+        XIAOMI_DATA_ID_LightIlluminance     =0x1007,
+        XIAOMI_DATA_ID_SoilMoisture         =0x1008,
+        XIAOMI_DATA_ID_SoilECvalue          =0x1009,
+        XIAOMI_DATA_ID_Power                =0x100A,  # Battery
+        XIAOMI_DATA_ID_TempAndHumidity      =0x100D,
+        XIAOMI_DATA_ID_Lock                 =0x100E,
+        XIAOMI_DATA_ID_Gate                 =0x100F,
+        XIAOMI_DATA_ID_Formaldehyde         =0x1010,
+        XIAOMI_DATA_ID_Bind                 =0x1011,
+        XIAOMI_DATA_ID_Switch               =0x1012,
+        XIAOMI_DATA_ID_RemAmCons            =0x1013,  # Remaining amount of consumables
+        XIAOMI_DATA_ID_Flooding             =0x1014,
+        XIAOMI_DATA_ID_Smoke                =0x1015,
+        XIAOMI_DATA_ID_Gas                  =0x1016,
+        XIAOMI_DATA_ID_NoOneMoves           =0x1017,
+        XIAOMI_DATA_ID_LightIntensity       =0x1018,
+        XIAOMI_DATA_ID_DoorSensor           =0x1019,
+        XIAOMI_DATA_ID_WeightAttributes     =0x101A,
+        XIAOMI_DATA_ID_NoOneMovesOverTime   =0x101B,  # No one moves over time
+        XIAOMI_DATA_ID_SmartPillow          =0x101C,
+        UNBOUND_DEVICE                      =0x0128,
+    ),
+    "data" / Switch(this.type,  # https://github.com/pvvx/ATC_MiThermometer/blob/master/InfoMijiaBLE/Mijia%20BLE%20Object%20Definition.md
+        {
+            "XIAOMI_DATA_ID_Temperature": Struct(  # 04
+                "type_length" / Const(b"\x02"),
+                "temperature" / Int16sl_x10,
+                "temperature_unit" / Computed("°C"),
+            ),
+            "XIAOMI_DATA_ID_Humidity": Struct(  # 06
+                "type_length" / Const(b"\x02"),  # ranging from 0-1000
+                "humidity" / Int16ul_x10,  # 0..100 %
+                "humidity_unit" / Computed("%"),
+            ),
+            "XIAOMI_DATA_ID_SoilECvalue": Struct(  # 09
+                "type_length" / Const(b"\x02"),
+                "conductivity" / Int16sl_x10,  # range: 0-5000
+                "conductivity_unit" / Computed("uS/cm"),
+            ),
+            "XIAOMI_DATA_ID_Power": Struct(  # 0A
+                "battery_length" / Const(b"\x01"),
+                "battery_level" / Int8ul,  # 0..100 %
+                "battery_level_unit" / Computed("%"),
+            ),
+            "XIAOMI_DATA_ID_TempAndHumidity": Struct(  # 0D
+                "type_length" / Const(b"\x04"),
+                "temperature" / Int16sl_x10,
+                "temperature_unit" / Computed("°C"),
+                "humidity" / Int16ul_x10,
+                "humidity_unit" / Computed("%"),
+            ),
+            "XIAOMI_DATA_ID_SoilMoisture": Struct(  # 08
+                "type_length" / Const(b"\x01"),
+                "moisture_level" / Int8ul,  # 0..100 %
+                "moisture_level_unit" / Computed("%"),
+            ),
+            "XIAOMI_DATA_ID_LightIlluminance": Struct(  # 07
+                "type_length" / Const(b"\x03"),
+                "illuminance" / Int24ul,  # Range: 0-120000
+                "illuminance_unit" / Computed("L"),
+            ),
+            "UNBOUND_DEVICE": Const(b"\x00"),
+        }
+    )
+)
+
+mi_like_format = Struct(
+    "version" / Computed(1),
+    "size" / Int8ul,  # e.g., 21
+    "uid" / Int8ul,  # 0x16, 16-bit UUID https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile/
+    "UUID" / ByteSwapped(Const(b"\xfe\x95")),  # 16-bit UUID for Members 0xFE95 Xiaomi Inc.
+    "ctrl" / BitStruct(  # Frame Control (https://github.com/pvvx/ATC_MiThermometer/blob/master/src/mi_beacon.h#L104-L124)
+        "Mesh" / Flag,  # 0: does not include Mesh; 1: includes Mesh. For standard BLE access products and high security level access, this item is mandatory to 0. This item is mandatory for Mesh access to 1. For more information about Mesh access, please refer to Mesh related documents
+        "Object_Include" / Flag,  # 0: does not contain Object; 1: contains Object
+        "Capability_Include" / Flag,  # 0: does not include Capability; 1: includes Capability. Before the device is bound, this bit is forced to 1
+        "MAC_Include" / Flag,  # 0: Does not include the MAC address; 1: includes a fixed MAC address (the MAC address is included for iOS to recognize this device and connect)
+        "isEncrypted" / Flag,  # 0: The package is not encrypted; 1: The package is encrypted
+        "Reserved" / BitsInteger(3),
+        "version" / BitsInteger(4),  # Version number (currently v5)
+        "Auth_Mode" / BitsInteger(2),  # 0: old version certification; 1: safety certification; 2: standard certification; 3: reserved
+        "solicited" / Flag,  # 0: No operation; 1: Request APP to register and bind. It is only valid when the user confirms the pairing by selecting the device on the developer platform, otherwise set to 0. The original name of this item was bindingCfm, and it was renamed to solicited "actively request, solicit" APP for registration and binding
+        "registered" / Flag,  # 0: The device is not bound; 1: The device is registered and bound. This item is used to indicate whether the device is reset
+    ),
+    "device_id" / Enum(Int16ul,  # Device type (https://github.com/pvvx/ATC_MiThermometer/blob/master/src/mi_beacon.h#L14-L35)
+        XIAOMI_DEV_ID_LYWSDCGQ       = 0x01AA,
+        XIAOMI_DEV_ID_CGG1           = 0x0347,
+        XIAOMI_DEV_ID_CGG1_ENCRYPTED = 0x0B48,
+        XIAOMI_DEV_ID_CGDK2          = 0x066F,
+        XIAOMI_DEV_ID_LYWSD02        = 0x045B,
+        XIAOMI_DEV_ID_LYWSD03MMC     = 0x055B,
+        XIAOMI_DEV_ID_CGD1           = 0x0576,
+        XIAOMI_DEV_ID_MHO_C303       = 0x06d3,
+        XIAOMI_DEV_ID_MHO_C401       = 0x0387,
+        XIAOMI_DEV_ID_JQJCY01YM      = 0x02DF,
+        XIAOMI_DEV_ID_HHCCJCY01      = 0x0098,
+        XIAOMI_DEV_ID_GCLS002        = 0x03BC,
+        XIAOMI_DEV_ID_HHCCPOT002     = 0x015D,
+        XIAOMI_DEV_ID_WX08ZM         = 0x040A,
+        XIAOMI_DEV_ID_MCCGQ02HL      = 0x098B,
+        XIAOMI_DEV_ID_YM_K1501       = 0x0083,
+        XIAOMI_DEV_ID_YM_K1501EU     = 0x0113,
+        XIAOMI_DEV_ID_V_SK152        = 0x045C,
+        XIAOMI_DEV_ID_SJWS01LM       = 0x0863,
+        XIAOMI_DEV_ID_MJYD02YL       = 0x07F6
+    ),
+    "counter" / Int8ul,  # 0..0xff..0 frame/measurement count
+    "MAC" / ReversedMacAddress,  # [0] - lo, .. [6] - hi digits
+    "mac_vendor" / MacVendor,
+    "data_point" / Switch(this.ctrl.isEncrypted,
+        {
+            True: MiLikeCodec(
+                Struct(
+                    "count_id" / Int24ul,
+                    "payload" / GreedyRange(mi_like_data)
+                ),
+                size_payload=5,
+            ),
+            False: GreedyRange(mi_like_data)
+        }
+    )
+)
+
+# -------------- bt_home_format ------------------------------------------------
+# "BTHome" advertising type, encrypted beacon unchecked
+
+bt_home_data = Struct(
+    "bt_home_type" / Enum(Int16ub,
+        # a: 0=uint (unsigned), 2=sint (signed), 4=float, 6=string, 8=MAC
+        # b: number of bytes; ab=SD; cc=DID=device id
+        #                          abcc
+        BT_HOME_packet_id       =0x0200,  # uint8
+        BT_HOME_battery         =0x0201,  # uint8, %
+        BT_HOME_temperature     =0x2302,  # sint16, 0.01 °C
+        BT_HOME_humidity        =0x0303,  # uint16, 0.01 %
+        BT_HOME_pressure        =0x0404,  # uint24, 0.01 hPa
+        BT_HOME_illuminance     =0x0405,  # uint24, 0.01 lux
+        BT_HOME_weight          =0x0306,  # uint16, 0.01 kg
+        BT_HOME_dewpoint        =0x2308,  # sint16, 0.01 °C
+        BT_HOME_count_i         =0x0209,  # uint8
+        BT_HOME_count_s         =0x0309,  # uint16
+        BT_HOME_count_m         =0x0409,  # uint24
+        BT_HOME_count_l         =0x0509,  # uint32
+        BT_HOME_energy          =0x040a,  # uint24, 0.001 kWh
+        BT_HOME_power           =0x040b,  # uint24, 0.01 W
+        BT_HOME_voltage         =0x030c,  # uint16, 0.001 V
+        BT_HOME_pm2x5           =0x030d,  # uint16, kg/m3
+        BT_HOME_pm10            =0x030e,  # uint16, kg/m3
+        BT_HOME_boolean         =0x020f,  # uint8
+        BT_HOME_switch          =0x0210,  # uint8
+        BT_HOME_opened          =0x0211,  # uint8
+    ),
+    "data" / Switch(this.bt_home_type,
+        {
+            "BT_HOME_packet_id": Struct(
+                "packet_id" / Int8ul,  # integer (0..255)
+            ),
+            "BT_HOME_count_l": Struct(
+                "count_l" / Int32ul,  # integer (0..4294967295)
+            ),
+            "BT_HOME_count": Struct(
+                "count" / Int8ul,  # integer (0..255)
+            ),
+            "BT_HOME_boolean": BitStruct(
+                Padding(7),
+                "boolean" / Flag,  # boolean
+            ),
+            "BT_HOME_switch": BitStruct(
+                Padding(7),
+                "switch" / Flag,  # boolean
+            ),
+            "BT_HOME_opened": BitStruct(
+                Padding(7),
+                "opened" / Flag,  # boolean
+            ),
+            "BT_HOME_voltage": Struct(
+                "battery_v" / Int16ul_x1000,
+                "battery_v_unit" / Computed("V"),
+            ),
+            "BT_HOME_temperature": Struct(
+                "temperature" / Int16sl_x100,
+                "temperature_unit" / Computed("°C"),
+            ),
+            "BT_HOME_humidity": Struct(
+                "humidity" / Int16ul_x100,
+                "humidity_unit" / Computed("%"),
+            ),
+            "BT_HOME_battery": Struct(
+                "battery_level" / Int8ul,  # 0..100 %
+                "battery_level_unit" / Computed("%"),
+            ),
+        }
+    )
+)
+
+# https://github.com/custom-components/ble_monitor/issues/548
+
+bt_home_format = Struct(  # Simplified formatting
+    "version" / Computed(1),
+    "size" / Int8ul,
+    "uid" / Int8ul,  # 0x16, 16-bit UUID
+    "UUID" / ByteSwapped(Const(b"\x18\x1c")),  # BT_HOME_GATT, SERVICE_UUID_USER_DATA, HA_BLE, no security
+    "bt_home_data" / GreedyRange(bt_home_data)
+)
+
+# -------------- bt_home_enc_format ------------------------------------------------
+# "BTHome" advertising type, encrypted beacon checked
+
+bt_home_enc_format = Struct(  # Simplified formatting
+    "version" / Computed(1),
+    "size" / Int8ul,
+    "uid" / Int8ul,  # 0x16, 16-bit UUID
+    "UUID" / ByteSwapped(Const(b"\x18\x1e")),  # Bond Management Service
+    "codec" / BtHomeCodec(
+        Struct(
+            "count_id" / Int32ul,  # https://github.com/custom-components/ble_monitor/issues/548#issuecomment-1059874327
+            "payload" / GreedyRange(bt_home_data)
+        ),
+        size_payload=11,
+    ),
+)
+
+# -------------- general_format ------------------------------------------------
+# All format types are embraced
+
+general_format = Struct(
+    "version" / Computed(1),
+    "custom_enc_format" / GreedyRange(custom_enc_format),
+    "custom_format" / GreedyRange(custom_format),
+    "atc1441_enc_format" / GreedyRange(atc1441_enc_format),
+    "atc1441_format" / GreedyRange(atc1441_format),
+    "mi_like_format" / GreedyRange(mi_like_format),
+    "bt_home_format" / GreedyRange(bt_home_format),
+    "bt_home_enc_format" / GreedyRange(bt_home_enc_format),
+)
+
+# -------------- LYWSD03MMC native structures ----------------------------------
+
+# BLE client connection, characteristic id 53 (Temperature and Humidity):
+native_temp_hum_v_values = Struct(
+    "version" / Computed(1),
+    "temperature" / Int16sl_x100,
+    "temperature_unit" / Computed("°C"),
+    "humidity" / Int8ul,  # 0..100 %
+    "humidity_unit" / Computed("%"),
+    "battery_v" / Int16ul_x1000,
+    "battery_v_unit" / Computed("V"),
+)
+
+# BLE client connection, characteristic id 66 (comfortable temp and humi):
+native_comfort_values = Struct(
+    "version" / Computed(1),
+    "temperature_high" / Int16sl_x100,
+    "temperature_low" / Int16sl_x100,
+    "humidity_high" / Int8ul,  # 0..100 %
+    "humidity_low" / Int8ul,  # 0..100 %
+    "humidity_unit" / Computed("%"),
+)

--- a/python-interface/construct_atc_mi_adapters.py
+++ b/python-interface/construct_atc_mi_adapters.py
@@ -1,0 +1,158 @@
+# Library module used by construct_atc_mi.py
+
+from construct import *  # pip3 install construct
+from Crypto.Cipher import AES  # pip3 install pycryptodome
+import re
+
+MacVendor = Switch(
+    this.MAC[:9],
+    {
+        "A4:C1:38:": Computed("Telink Semiconductor"),
+    },
+    default=Computed("Unknown vendor"),
+)
+
+
+class BtHomeCodec(Tunnel):
+    def __init__(self, subcon, size_payload, bindkey=b'', mac_address=b''):
+        super().__init__(subcon)
+        self.default_bindkey = bindkey
+        self.size_payload = size_payload
+        self.def_mac = mac_address
+
+    def bindkey(self, ctx):
+        try:
+            return (ctx._params.bindkey or self.default_bindkey)
+        except Exception as e:
+            return self.default_bindkey
+
+    def mac(self, ctx):
+        try:
+            return (ctx._params.mac_address or self.def_mac)
+        except Exception:
+            return self.def_mac
+
+    def decrypt(self, ctx, nonce, encrypted_data, mic):
+        bindkey = self.bindkey(ctx)
+        if not bindkey:
+            raise ValueError('Missing bindkey during decrypt().')
+        cipher = AES.new(bindkey, AES.MODE_CCM, nonce=nonce, mac_len=4)
+        cipher.update(b"\x11")
+        try:
+            return cipher.decrypt_and_verify(encrypted_data, mic), None
+        except Exception as e:
+            return None, "Decryption error: " + str(e)
+
+    def encrypt(self, ctx, nonce, msg):
+        bindkey = self.bindkey(ctx)
+        if not bindkey:
+            raise ValueError('Missing bindkey during encrypt().')
+        cipher = AES.new(bindkey, AES.MODE_CCM, nonce=nonce, mac_len=4)
+        cipher.update(b"\x11")
+        return cipher.encrypt_and_digest(msg)
+
+    def _decode(self, obj, ctx, path):
+        mac = self.mac(ctx)
+        if not mac:
+            raise ValueError('Missing MAC address during _decode().')
+        pkt = ctx._io.getvalue()[2:]
+        uuid = pkt[0:2]
+        encrypted_data = pkt[2:-8]
+        count_id = pkt[-8:-4]  # Int32ul
+        mic = pkt[-4:]
+        nonce = mac + uuid + count_id
+        msg, error = self.decrypt(ctx, nonce, encrypted_data, mic)
+        if error:
+            return error
+        return count_id + msg
+
+    def _encode(self, obj, ctx, path):
+        mac = self.mac(ctx)
+        if not mac:
+            raise ValueError('Missing MAC address during _encode().')
+        count_id = bytes(obj)[:4]  # Int32ul
+        uuid16 = b"\x1e\x18"
+        nonce = mac + uuid16 + count_id
+        ciphertext, mic = self.encrypt(
+            ctx, nonce, bytes(obj)[4:self.size_payload + 4])
+        return ciphertext + count_id + mic
+
+
+class AtcMiCodec(BtHomeCodec):
+    def _decode(self, obj, ctx, path):
+        mac = self.mac(ctx)
+        if not mac:
+            raise ValueError('Missing MAC address during _decode().')
+        payload = bytes(obj)[1:]
+        cipherpayload = payload[:-4]
+        header_bytes = ctx._io.getvalue()[:4]  # b'\x0e\x16\x1a\x18' (custom_enc) or b'\x0b\x16\x1a\x18' (atc1441_enc)
+        nonce = mac[::-1] + header_bytes + bytes(obj)[:1]
+        token = payload[-4:] #mic
+        msg, error = self.decrypt(ctx, nonce, cipherpayload, token)
+        if error:
+            return error
+        return msg + bytes(len(obj) - len(msg))
+
+    def _encode(self, obj, ctx, path):
+        mac = self.mac(ctx)
+        if not mac:
+            raise ValueError('Missing MAC address during _encode().')
+        header_bytes = ctx._io.getvalue()[:4] + b'\xbd'  # b'\x0e\x16\x1a\x18\xbd' (custom_enc) or b'\x0b\x16\x1a\x18\xbd' (atc1441_enc)
+        nonce = mac[::-1] + header_bytes
+        ciphertext, mic = self.encrypt(
+            ctx, nonce, bytes(obj)[:self.size_payload])
+        return b'\xbd' + ciphertext + mic
+
+
+class MiLikeCodec(BtHomeCodec):
+    def _decode(self, obj, ctx, path):
+        payload = obj
+        cipherpayload = payload[:-7]
+        #mac = ctx._io.getvalue()[9:15:-1]
+        mac = self.mac(ctx)
+        dev_id = ctx._io.getvalue()[6:8]  # pid, PRODUCT_ID
+        cnt = ctx._io.getvalue()[8:9]  # encode frame cnt
+        count_id = payload[-7:-4]  # Int24ul
+        nonce = mac[::-1] + dev_id + cnt + count_id
+        token = payload[-4:] #mic
+        msg, error = self.decrypt(ctx, nonce, cipherpayload, token)
+        if error:
+            return error
+        return count_id + msg
+
+    def _encode(self, obj, ctx, path):
+        #mac = ctx._io.getvalue()[9:15:-1]
+        mac = self.mac(ctx)
+        dev_id = ctx._io.getvalue()[6:8]  # pid, PRODUCT_ID
+        cnt = ctx._io.getvalue()[8:9]  # encode frame cnt
+        count_id = bytes(obj)[:3]  # Int24ul
+        nonce = mac[::-1] + dev_id + cnt + count_id
+        ciphertext, mic = self.encrypt(
+            ctx, nonce, bytes(obj)[3:self.size_payload + 3])
+        return ciphertext + count_id + mic
+
+
+MacAddress = ExprAdapter(Byte[6],
+    decoder = lambda obj, ctx: ":".join("%02x" % b for b in obj).upper(),
+    encoder = lambda obj, ctx: bytes.fromhex(re.sub(r'[.:\- ]', '', obj))
+)
+ReversedMacAddress = ExprAdapter(Byte[6],
+    decoder = lambda obj, ctx: ":".join("%02x" % b for b in obj[::-1]).upper(),
+    encoder = lambda obj, ctx: bytes.fromhex(re.sub(r'[.:\- ]', '', obj))[::-1]
+)
+Int16ub_x1000 = ExprAdapter(Int16ub,
+        obj_ / 1000, lambda obj, ctx: int(float(obj) * 1000))
+Int16ul_x1000 = ExprAdapter(Int16ul,
+        obj_ / 1000, lambda obj, ctx: int(float(obj) * 1000))
+Int16ul_x100 = ExprAdapter(
+    Int16ul, obj_ / 100, lambda obj, ctx: int(float(obj) * 100))
+Int16sl_x100 = ExprAdapter(
+    Int16sl, obj_ / 100, lambda obj, ctx: int(float(obj) * 100))
+Int16ub_x10 = ExprAdapter(
+    Int16ub, obj_ / 10, lambda obj, ctx: int(float(obj) * 10))
+Int16ul_x10 = ExprAdapter(
+    Int16ul, obj_ / 10, lambda obj, ctx: int(float(obj) * 10))
+Int16sb_x10 = ExprAdapter(
+    Int16sb, obj_ / 10, lambda obj, ctx: int(float(obj) * 10))
+Int16sl_x10 = ExprAdapter(
+    Int16sl, obj_ / 10, lambda obj, ctx: int(float(obj) * 10))

--- a/python-interface/construct_module.py
+++ b/python-interface/construct_module.py
@@ -1,0 +1,58 @@
+# Library module used by atc_mi_advertising.py
+
+# This module shall be reloadable, including relevant "construct" submodules
+
+import construct_atc_mi
+from construct_gallery import GalleryItem
+from importlib import reload
+import construct_editor.core.custom as custom
+
+# Allow reloading submodules (load_construct_selector)
+import construct_atc_mi_adapters
+reload(construct_atc_mi_adapters)
+reload(construct_atc_mi)
+
+# Set custom adapters in construct_editor
+custom.add_custom_tunnel(construct_atc_mi.BtHomeCodec, "BtHomeCodec")
+custom.add_custom_tunnel(construct_atc_mi.AtcMiCodec, "AtcMiCodec")
+custom.add_custom_tunnel(construct_atc_mi.MiLikeCodec, "MiLikeCodec")
+custom.add_custom_adapter(
+    construct_atc_mi.ExprAdapter,
+    "Value",
+    custom.AdapterObjEditorType.String)
+custom.add_custom_adapter(
+    construct_atc_mi.ReversedMacAddress,
+    "ReversedMacAddress",
+    custom.AdapterObjEditorType.String)
+custom.add_custom_adapter(
+    construct_atc_mi.MacAddress,
+    "MacAddress",
+    custom.AdapterObjEditorType.String)
+
+# Set construct_gallery
+gallery_descriptor = {
+    "general_format": GalleryItem(
+        construct=construct_atc_mi.general_format,
+    ),
+    "custom_format": GalleryItem(
+        construct=construct_atc_mi.custom_format,
+    ),
+    "custom_enc_format": GalleryItem(
+        construct=construct_atc_mi.custom_enc_format,
+    ),
+    "mi_like_format": GalleryItem(
+        construct=construct_atc_mi.mi_like_format,
+    ),
+    "atc1441_format": GalleryItem(
+        construct=construct_atc_mi.atc1441_format,
+    ),
+    "atc1441_enc_format": GalleryItem(
+        construct=construct_atc_mi.atc1441_enc_format,
+    ),
+    "bt_home_format": GalleryItem(
+        construct=construct_atc_mi.bt_home_format,
+    ),
+    "bt_home_enc_format": GalleryItem(
+        construct=construct_atc_mi.bt_home_enc_format,
+    ),
+}

--- a/python-interface/get_characteristics.py
+++ b/python-interface/get_characteristics.py
@@ -1,0 +1,116 @@
+import asyncio
+from bleak import BleakClient, exc
+from construct_atc_mi import *
+import argparse
+import time
+
+char_dict = {
+    "00001800-0000-1000-8000-00805f9b34fb": [
+        [[2], GreedyString("utf8"), 0, False]
+    ],
+    "0000180a-0000-1000-8000-00805f9b34fb": [
+        [[13, 15, 17, 19, 21, 23], GreedyString("utf8"), 0, False]
+    ],
+    "0000180f-0000-1000-8000-00805f9b34fb": [
+        [[26], Int8ul, 1, False]  # Battery Level
+    ],
+    "0000181a-0000-1000-8000-00805f9b34fb": [  # custom format
+        [[30], Int16sl_x10, 2, False],  # Temperature Celsius
+        [[33], Int16sl_x100, 2, False],  # Temperature
+        [[36], Int16ul_x100, 2, False],  # Humidity
+    ],
+    "ebe0ccb0-7a0a-4b0c-8a1a-6ff2997da3a6": [  # LYWSD03MMC native format
+        [[57], Int8ul, 1, False],  # Batt
+        [[53], native_temp_hum_v_values, 5, False],  # Temperature and Humidity
+        [[34], Int32ul, 4, False],  # Time
+        [[37], Int64ul, 8, False],  # Data Count
+        [[66], native_comfort_values, 6, False],  # comfortable temp and humi
+    ],
+    "0000fe95-0000-1000-8000-00805f9b34fb": [
+        [[95], GreedyString("utf8"), 0, True],  # version & service.description
+    ]
+}
+
+async def atc_characteristics(client, verbosity=False):
+    char_list = []
+    for service in client.services:
+        if verbosity:
+            print(">Service", service)
+        for char in service.characteristics:
+            if "read" not in char.properties:
+                continue
+            if verbosity:
+                name_bytes = await client.read_gatt_char(char.uuid)
+                print("    Characteristic", char, "=", name_bytes.hex(' '),
+                    "=", name_bytes)
+            if service.uuid in char_dict:
+                for item in char_dict[service.uuid]:
+                    if char.handle not in item[0]:
+                        continue
+                    name_bytes = await client.read_gatt_char(char.uuid)
+                    if not item[2] or len(name_bytes) == item[2]:
+                        if item[3]:
+                            char_list.append([char.handle, service.description,
+                                item[1].parse(name_bytes)])
+                        else:
+                            char_list.append([char.handle, char.description,
+                                item[1].parse(name_bytes)])
+
+    return char_list
+
+async def main(args):
+    for times in range(args.attempts):
+        if args.verbosity:
+            print(f"Attempt n. {times + 1}")
+        try:
+            async with BleakClient(args.address, timeout=40.0) as client:
+                for i in await atc_characteristics(
+                        client, verbosity=args.verbosity):
+                    print(i[0], i[1], i[2])
+                break
+        except OSError as e:
+            if args.show_error:
+                print("get_services_task interrupted.", e)
+        except asyncio.exceptions.TimeoutError as e:
+            if args.show_error:
+                print("Connection timeout error.", e)
+        except asyncio.exceptions.CancelledError as e:
+            if args.show_error:
+                print("Connection error (Cancelled).", e)
+        except exc.BleakError as e:
+            if args.show_error:
+                print("GATT error:", e)
+        time.sleep(2)
+    if times + 1 == args.attempts:
+        print(f"Cannot connect after {args.attempts} attempts.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        epilog='Xiaomi Mijia Thermometer - List BLE Characteristics')
+    parser.add_argument(
+        '-e',
+        "--error",
+        dest='show_error',
+        action='store_true',
+        help="show error information")
+    parser.add_argument(
+        '-v',
+        "--verbosity",
+        dest='verbosity',
+        action='store_true',
+        help="print process information")
+    parser.add_argument(
+        '-m',
+        '--mac',
+        dest='address',
+        action="store",
+        help='MAC Address',
+        required=True)
+    parser.add_argument(
+        '-a',
+        '--attempts',
+        dest='attempts',
+        type=int,
+        help='max number of attempts (default=20)',
+        default=20)
+    asyncio.run(main(parser.parse_args()))

--- a/python-interface/requirements.txt
+++ b/python-interface/requirements.txt
@@ -1,0 +1,6 @@
+wxPython
+construct
+construct-editor
+bleak
+construct-gallery
+pycryptodome

--- a/python-interface/test_atc_formats.py
+++ b/python-interface/test_atc_formats.py
@@ -1,0 +1,189 @@
+import construct_atc_mi
+import wx
+import sys
+from construct_gallery import ConstructGallery, GalleryItem
+import construct_editor.core.custom as custom
+from collections import OrderedDict
+
+custom.add_custom_tunnel(construct_atc_mi.BtHomeCodec, "BtHomeCodec")
+custom.add_custom_tunnel(construct_atc_mi.AtcMiCodec, "AtcMiCodec")
+custom.add_custom_tunnel(construct_atc_mi.MiLikeCodec, "MiLikeCodec")
+custom.add_custom_adapter(
+    construct_atc_mi.ExprAdapter,
+    "ComputedValue",
+    custom.AdapterObjEditorType.String)
+custom.add_custom_adapter(
+    construct_atc_mi.ReversedMacAddress,
+    "ReversedMacAddress",
+    custom.AdapterObjEditorType.String)
+custom.add_custom_adapter(
+    construct_atc_mi.MacAddress,
+    "MacAddress",
+    custom.AdapterObjEditorType.String)
+
+app = wx.App(False)
+frame = wx.Frame(None, title="ATC MI Formats", size=(1000, 500))
+
+gallery_descriptor = {
+    "general_format": GalleryItem(
+        construct=construct_atc_mi.general_format,
+    ),
+    "custom_format": GalleryItem(
+        construct=construct_atc_mi.custom_format,
+    ),
+    "custom_enc_format": GalleryItem(
+        construct=construct_atc_mi.custom_enc_format,
+    ),
+    "mi_like_format": GalleryItem(
+        construct=construct_atc_mi.mi_like_format,
+    ),
+    "atc1441_format": GalleryItem(
+        construct=construct_atc_mi.atc1441_format,
+    ),
+    "atc1441_enc_format": GalleryItem(
+        construct=construct_atc_mi.atc1441_enc_format,
+    ),
+    "bt_home_format": GalleryItem(
+        construct=construct_atc_mi.bt_home_format,
+    ),
+    "bt_home_enc_format": GalleryItem(
+        construct=construct_atc_mi.bt_home_enc_format,
+    ),
+}
+
+ordered_samples = OrderedDict(
+# ordered_samples OrderedDict for the overall data, independent from the
+# previous gallery_descriptor. Notice that if a reference is used "mac_address",
+# reference_label and key_label must be set in ConstructGallery
+    [
+        (
+            "custom",
+            {
+                "binary": bytes.fromhex(
+                    "12 16 1a 18 cc bb aa 38 c1 a4 6c 07 fa 13 d6 0a 52 09 0f"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "custom_enc",
+            {
+                "binary": bytes.fromhex(
+                    "0e 16 1a 18 bd 86 c5 3f fa b9 00 c1 51 58 59"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "atc1441",
+            {
+                "binary": bytes.fromhex(
+                    "10 16 1a 18 a4 c1 38 aa bb cc 00 ce 33 43 0a 6e c3"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "atc1441_enc",
+            {
+                "binary": bytes.fromhex(
+                    "0b 16 1a 18 bd e9 b7 5d b8 56 f3 03"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "bt_home (temp, humidity, batt%)",
+            {
+                "binary": bytes.fromhex(
+                    "11 16 1c 18 02 00 56 23 02 6c 07 03 03 ff 13 02 01 4e"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "bt_home (batt v)",
+            {
+                "binary": bytes.fromhex(
+                    "0d 16 1c 18 02 00 63 02 10 01 03 0c d9 0a"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "bt_home_enc (temp, humidity, batt%)",
+            {
+                "binary": bytes.fromhex(
+                    "16 16 1e 18 83 93 db a2 55 4c d8 04 be ab 78 cf b3 00 "
+                    "00 7d 6a 1c d2"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "bt_home_enc (batt v)",
+            {
+                "binary": bytes.fromhex(
+                    "12 16 1e 18 12 79 94 44 eb 3a 3f e4 b3 00 00 59 62 3a 29"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "mi_like (temp, humidity)",
+            {
+                "binary": bytes.fromhex(
+                    "15 16 95 fe 50 58 5b 05 1b cc bb aa 38 c1 a4 0d 10 04 "
+                    "be 00 00 02"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "mi_like (batt)",
+            {
+                "binary": bytes.fromhex(
+                    "12 16 95 fe 50 58 5b 05 22 cc bb aa 38 c1 a4 0a 10 01 "
+                    "4f"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "mi_like_enc (temperature)",
+            {
+                "binary": bytes.fromhex(
+                    "1a 16 95 fe 58 58 5b 05 f4 cc bb aa 38 c1 a4 13 df 92 "
+                    "a8 1c b3 00 00 ac c4 6f da"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "mi_like_enc (humidity %)",
+            {
+                "binary": bytes.fromhex(
+                    "1a 16 95 fe 58 58 5b 05 95 cc bb aa 38 c1 a4 d5 25 d9 "
+                    "74 ec 14 00 00 9b e1 de 3c"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+        (
+            "mi_like_enc (battery %)",
+            {
+                "binary": bytes.fromhex(
+                    "19 16 95 fe 58 58 5b 05 ed cc bb aa 38 c1 a4 de 6d f0 "
+                    "74 b3 00 00 f2 ef 0e 53"),
+                "mac_address": "A4:C1:38:AA:BB:CC",
+            },
+        ),
+    ]
+)
+
+ref_key_descriptor = {  # ref_key_descriptor dictionary for the overall data
+    "A4:C1:38:AA:BB:CC": {"bindkey": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+}
+
+
+ConstructGallery(frame,
+    gallery_descriptor=gallery_descriptor,
+    ordered_samples=ordered_samples,
+    ref_key_descriptor=ref_key_descriptor,
+    reference_label="MAC address",
+    key_label="Bindkey",
+    description_label="Description",
+    col_name_width=200,
+    col_type_width=150
+)
+
+frame.Show(True)
+app.MainLoop()


### PR DESCRIPTION
Thanks for this repo.

This PR proposes adding a python-interface section, which provides Python components to represent the data model of the custom firmware, as well as a documented interface and a testing tool to decode, show and edit the BLE advertisements delivered via the custom firmware.

The main element is the symmetric Python library that declaratively defines a data structure describing all the advertisement frames produced by the custom firmware.

The testing tool is an easy-to-use BLE Advertisement Browser GUI.