### PR TITLE
Fix °C->°F calculation

### DIFF
--- a/src/lcd.c
+++ b/src/lcd.c
@@ -199,7 +199,7 @@ void lcd(void) {
 		}
 		if (cfg.flg.temp_F_or_C) {
 			show_temp_symbol(TMP_SYM_F); // "°F"
-			show_big_number_x10(((int32_t)((int32_t)measured_data.temp * 9)/ 50) + 3200); // convert C to F
+			show_big_number_x10(((int32_t)((int32_t)measured_data.temp * 9)/ 50) + 320); // convert C to F
 		} else {
 			show_temp_symbol(TMP_SYM_C); // "°C"
 			show_big_number_x10(measured_data.temp_x01);


### PR DESCRIPTION
This can be confirmed with the following test program:
```c
#include <stdio.h>
#include <stdint.h>

int main()
{
    int16_t temp = 2000;
    printf("%d\n", (((temp / 5) * 9) + 3200) / 10); // Old: 680
    printf("%d\n", ((int32_t)((int32_t)temp * 9)/ 50) + 3200); // New: 3560
    printf("%d\n", ((int32_t)((int32_t)temp * 9)/ 50) + 320); // Fixed: 680
    return 0;
}
```