### PR TITLE
atc_mi_interface v2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 .idea/
 # generated output
 out/*
+python-interface/atc_mi_interface.egg-info/*
+python-interface/build/*
+python-interface/dist/*

--- a/python-interface/README.md
+++ b/python-interface/README.md
@@ -17,7 +17,7 @@ The base components used here are:
 
 The software in this section includes:
 
-- a [*construct* data model](atc_mi_interface/atc_mi_construct.py) representing the *custom*, *atc1441*, *mi_like* and *bt_home* formats, respectively in clear and encrypted structures, with a documented interface to decode, browse and build the structures of BLE advertisements;
+- a [*construct* data model](atc_mi_interface/atc_mi_construct.py) representing the *custom*, *atc1441*, *mi_like*, *bt_home* (version 1) and *bt_home_v2* (version 2) formats, respectively in clear and encrypted structures, with a documented interface to decode, browse and build the structures of BLE advertisements;
 - the [`atc_mi_advertising_format(advertisement_data)`](atc_mi_interface/atc_mi_adv_format.py) function, to easily process BLE advertisements;
 - an easy to use [BLE Advertisement Browser GUI](atc_mi_interface/atc_mi_advertising.py) based on the [wxPython](https://www.wxpython.org/) cross-platform desktop GUI toolkit, including controls on the BLE advertisements, map of MAC addresses, bindkeys, etc;
 - a [configuration tool](atc_mi_interface/atc_mi_config.py) allowing to browse and edit the configuration parameters of the latest releases of the "pvvx" firmware, with a command-line interface and optionally with a GUI, including the possibility to use this configuration feature as an API.
@@ -159,7 +159,7 @@ Parsing a [*custom* frame](https://github.com/pvvx/ATC_MiThermometer#custom-form
 ```python
 from atc_mi_interface import general_format
 print(general_format.parse(bytes.fromhex(
-    '12 16 1a 18 5c c8 ee 38 c1 a4 b0 08 c3 14 ca 0a 50 14 05')))
+    "12 16 1a 18 5c c8 ee 38 c1 a4 b0 08 c3 14 ca 0a 50 14 05")))
 ```
 
 Output:
@@ -173,17 +173,17 @@ Container:
             version = 1
             size = 18
             uid = 22
-            UUID = b'\x18\x1a' (total 2)
-            MAC = u'A4:C1:38:EE:C8:5C' (total 17)
-            mac_vendor = u'Telink Semiconductor' (total 20)
+            UUID = b"\x18\x1a" (total 2)
+            MAC = u"A4:C1:38:EE:C8:5C" (total 17)
+            mac_vendor = u"Telink Semiconductor" (total 20)
             temperature = 22.24
-            temperature_unit = u'°C' (total 2)
+            temperature_unit = u"°C" (total 2)
             humidity = 53.15
-            humidity_unit = u'%' (total 1)
+            humidity_unit = u"%" (total 1)
             battery_v = 2.762
-            battery_v_unit = u'V' (total 1)
+            battery_v_unit = u"V" (total 1)
             battery_level = 80
-            battery_level_unit = u'%' (total 1)
+            battery_level_unit = u"%" (total 1)
             counter = 20
             flags = Container:
                 humidity_trigger = False
@@ -196,14 +196,15 @@ Container:
     mi_like_format = ListContainer:
     bt_home_format = ListContainer:
     bt_home_enc_format = ListContainer:
+    bt_home_v2_format = ListContainer:
 ```
 
-The following example shows how to parse any type of format (*custom*, *atc1441*, *mi_like*, *bt_home*, either they are encrypted or not). The right format is automatically selected basing on the frame type:
+The following example shows how to parse any type of format (*custom*, *atc1441*, *mi_like*, *bt_home*, *bt_home_v2*, either they are encrypted or not). The right format is automatically selected basing on the frame type:
 
 ```python
 from atc_mi_interface import general_format
 
-frame1 = bytes.fromhex('12 16 1a 18 cc bb aa 38 c1 a4 77 07 88 13 ca 0a 50 01 07')
+frame1 = bytes.fromhex("12 16 1a 18 cc bb aa 38 c1 a4 77 07 88 13 ca 0a 50 01 07")
 
 atc_mi_data = general_format.parse(frame1)
 
@@ -214,9 +215,9 @@ print("battery_v:", atc_mi_data.search_all("^battery_v"))
 
 print()
 
-frame2 = bytes.fromhex('16 16 1e 18 ec 12 cf e5 00 00 3a f3 95 3c a0 5a 7d 03 00 2a ea f8 ea')
+frame2 = bytes.fromhex("16 16 1e 18 ec 12 cf e5 00 00 3a f3 95 3c a0 5a 7d 03 00 2a ea f8 ea")
 bindkey = bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
-mac_address = bytes.fromhex("A4:C1:38:AA:BB:CC".replace(':', ''))
+mac_address = bytes.fromhex("A4:C1:38:AA:BB:CC".replace(":", ""))
 
 atc_mi_data = general_format.parse(frame2, bindkey=bindkey, mac_address=mac_address)
 
@@ -229,14 +230,14 @@ print("battery_v:", atc_mi_data.search_all("^battery_v"))
 Output:
 
 ```python
-temperature: [19.11, '°C']
-humidity: [50.0, '%', False]
-battery_level: [80, '%']
-battery_v: [2.762, 'V']
+temperature: [19.11, "°C"]
+humidity: [50.0, "%", False]
+battery_level: [80, "%"]
+battery_v: [2.762, "V"]
 
-temperature: [20.0, '°C']
-humidity: [50.0, '%']
-battery_level: [100, '%']
+temperature: [20.0, "°C"]
+humidity: [50.0, "%"]
+battery_level: [100, "%"]
 battery_v: []
 ```
 
@@ -266,18 +267,18 @@ custom_format.build(
             "input_gpio_value": True,
         },
     }
-).hex(' ')
+).hex(" ")
 ```
 
 Output:
 
 ```
-'12 16 1a 18 cc bb aa 38 c1 a4 77 07 88 13 ca 0a 50 01 07'
+"12 16 1a 18 cc bb aa 38 c1 a4 77 07 88 13 ca 0a 50 01 07"
 ```
 
 ## Encrypting and decrypting
 
-All encoded versions of the *construct* structures (*custom_enc_format*, *atc1441_enc_format*, *bt_home_enc_format*, *mi_like_format* with the "isEncrypted" flag) support the following additional parameters:
+All encoded versions of the *construct* structures (*custom_enc_format*, *atc1441_enc_format*, *bt_home_enc_format*, *mi_like_format* with the "isEncrypted" flag, *bt_home_v2_format* with the "Encryption" flag) support the following additional parameters:
 
 - `mac_address`: MAC address in bytes (e.g., `bytes.fromhex("A4:C1:38:AA:BB:CC".replace(":", ""))`)
 - `bindkey`: Bindkey in bytes (e.g., `bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")`)
@@ -287,12 +288,9 @@ Alternatively (but not suggested), if the same MAC address and key are needed fo
 ```python
 ...
     "codec" / AtcMiCodec(
-        Aligned(11,
-            Struct(
-                ...
-            )
+        Struct(
+            ...
         ),
-        size_payload=6,
         mac_address=bytes.fromhex("A4:C1:38:AA:BB:CC".replace(":", "")),
         bindkey=bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
     ),
@@ -323,14 +321,14 @@ Container:
             version = 1
             size = 14
             uid = 22
-            UUID = b'\x18\x1a' (total 2)
+            UUID = b"\x18\x1a" (total 2)
             codec = Container:
                 temperature = 19.11
-                temperature_unit = u'°C' (total 2)
+                temperature_unit = u"°C" (total 2)
                 humidity = 50.0
-                humidity_unit = u'%' (total 1)
+                humidity_unit = u"%" (total 1)
                 battery_level = 93
-                battery_level_unit = u'%' (total 1)
+                battery_level_unit = u"%" (total 1)
                 flags = Container:
                     humidity_trigger = False
                     temp_trigger = True
@@ -343,6 +341,7 @@ Container:
     mi_like_format = ListContainer:
     bt_home_format = ListContainer:
     bt_home_enc_format = ListContainer:
+    bt_home_v2_format = ListContainer:
 ```
 
 Building the frame with the reverse process:
@@ -371,25 +370,25 @@ custom_enc_format.build(
     },
     mac_address=bytes.fromhex("A4:C1:38:AA:BB:CC".replace(":", "")),
     bindkey=bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
-).hex(' ')
+).hex(" ")
 ```
 
 Output:
 
 ```
-'0e 16 1a 18 bd 9d c5 4e fa b8 08 56 6b e8 7f'
+"0e 16 1a 18 bd 9d c5 4e fa b8 08 56 6b e8 7f"
 ```
 
 For the build process, generally `Container` is mapped to a dictionary (`{ ... }`), `ListContainer` to a list (`[ ... ]`) and `(enum)` with a normal `key: value` inside a dictionary (with the strings in quotes).
 
-Another parsing example using as input an array of bytes encoded with `bt_home_enc_format`:
+Another parsing example using as input an array of bytes encoded with encrypted `bt_home_v2_format`:
 
 ```python
-from atc_mi_interface import bt_home_enc_format
+from atc_mi_interface import bt_home_v2_format
 
 print(
-    bt_home_enc_format.parse(
-        bytes.fromhex("16 16 1e 18 23 1b 90 11 7c cd e0 4b a1 73 26 5c 7d 03 00 68 8c 9b 84"),
+    bt_home_v2_format.parse(
+        bytes.fromhex("14 16 d2 fc 41 95 b0 ef da 78 9d d9 53 b0 26 00 00 93 41 62 6f"),
         mac_address=bytes.fromhex("A4:C1:38:AA:BB:CC".replace(":", "")),
         bindkey=bytes.fromhex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
     )
@@ -401,54 +400,67 @@ Output:
 ```python
 Container:
     version = 1
-    size = 22
+    size = 20
     uid = 22
-    UUID = b'\x18\x1e' (total 2)
-    codec = Container:
-        count_id = 228700
+    UUID = b"\xfc\xd2" (total 2)
+    DevInfo = Container:
+        Version = 2
+        Reserved2 = 0
+        Trigger = False
+        Reserved1 = 0
+        Encryption = True
+    data_point = Container:
+        count_id = 9904
         payload = ListContainer:
             Container:
-                bt_home_type = (enum) BT_HOME_temperature 8962
-                data = Container:
-                    temperature = 19.11
-                    temperature_unit = u'°C' (total 2)
-            Container:
-                bt_home_type = (enum) BT_HOME_humidity 771
-                data = Container:
-                    humidity = 50.0
-                    humidity_unit = u'%' (total 1)
-            Container:
-                bt_home_type = (enum) BT_HOME_battery 513
+                bt_home_v2_type = (enum) BtHomeID_battery 1
                 data = Container:
                     battery_level = 80
-                    battery_level_unit = u'%' (total 1)
+                    battery_level_unit = u"%" (total 1)
+            Container:
+                bt_home_v2_type = (enum) BtHomeID_temperature 2
+                data = Container:
+                    temperature = 19.2
+                    temperature_unit = u"°C" (total 2)
+            Container:
+                bt_home_v2_type = (enum) BtHomeID_humidity 3
+                data = Container:
+                    humidity = 62.22
+                    humidity_unit = u"%" (total 1)
 ```
 
 Reverse process:
 
 ```python
-from atc_mi_interface import bt_home_enc_format
+from atc_mi_interface import bt_home_v2_format
 
-bt_home_enc_format.build(
+bt_home_v2_format.build(
     {
-        "size": 22,
+        "size": 20,
         "uid": 22,
-        "UUID": b"\x18\x1e",
-        "codec": {
-            "count_id": 228700,
+        "UUID": b"\xfc\xd2",
+        "DevInfo": {
+            "Encryption": True,
+            "Reserved1": 0,
+            "Reserved2": 0,
+            "Trigger": False,
+            "Version": 2,
+        },
+        "data_point": {
+            "count_id": 9904,
             "payload": [
                 {
-                    "bt_home_type": "BT_HOME_temperature",
-                    "data": {"temperature": 19.11},
+                    "bt_home_v2_type": "BtHomeID_battery",
+                    "data": {"battery_level": 80}
                 },
                 {
-                    "bt_home_type": "BT_HOME_humidity",
-                    "data": {"humidity": 50.0},
+                    "bt_home_v2_type": "BtHomeID_temperature",
+                    "data": {"temperature": 19.2}
                 },
                 {
-                    "bt_home_type": "BT_HOME_battery",
-                    "data": {"battery_level": 80},
-                }
+                    "bt_home_v2_type": "BtHomeID_humidity",
+                    "data": {"humidity": 62.22}
+                },
             ]
         }
     },
@@ -460,7 +472,7 @@ bt_home_enc_format.build(
 Output:
 
 ```
-'16 16 1e 18 23 1b 90 11 7c cd e0 4b a1 73 26 5c 7d 03 00 68 8c 9b 84'
+"14 16 d2 fc 41 95 b0 ef da 78 9d d9 53 b0 26 00 00 93 41 62 6f"
 ```
 
 ## Reading and updating single values
@@ -472,7 +484,7 @@ As an example, we first setup a `construct` collection from `cfg`, named `cfg_co
 ```python
 from atc_mi_interface import cfg
 
-CFG_BYTES = '43 85 10 00 00 28 04 A9 31 31 04 B4'
+CFG_BYTES = "43 85 10 00 00 28 04 A9 31 31 04 B4"
 cfg_constr = cfg.parse(bytes.fromhex(CFG_BYTES))
 
 cfg_constr
@@ -481,7 +493,7 @@ cfg_constr
 Output:
 
 ```python
-Container(version=1, firmware_version=Container(major=4, minor=3), flg=Container(lp_measures=True, tx_measures=False, show_batt_enabled=False, temp_F_or_C=uEnumIntegerString.new(0, 'temp_C'), blinking_time_smile=uEnumIntegerString.new(0, 'blinking_smile'), comfort_smiley=True, advertising_type=uEnumIntegerString.new(1, 'adv_type_custom')), flg2=Container(screen_off=False, longrange=False, bt5phy=False, adv_flags=True, adv_crypto=False, smiley=uEnumIntegerString.new(0, 'smiley_off')), temp_offset=0.0, temperature_unit=u'°C', humi_offset=0.0, humidity_unit=u'%', advertising_interval=2.5, adv_int_unit=u'sec.', measure_interval=4, rf_tx_power=uEnumIntegerString.new(169, 'RF_POWER_Positive_0p04_dBm'), connect_latency=1.0, connect_latency_unit=u'sec.', min_step_time_update_lcd=2.45, min_s_t_upd_lcd_unit=u'sec.', hw_cfg=Container(sensor=uEnumIntegerString.new(0, 'sensor_SHT4x'), reserved=0, hwver=uEnumIntegerString.new(4, 'hwver_LYWSD03MMC_B1_6')), averaging_measurements=180)
+Container(version=1, firmware_version=Container(major=4, minor=3), flg=Container(lp_measures=True, tx_measures=False, show_batt_enabled=False, temp_F_or_C=uEnumIntegerString.new(0, "temp_C"), blinking_time_smile=uEnumIntegerString.new(0, "blinking_smile"), comfort_smiley=True, advertising_type=uEnumIntegerString.new(1, "adv_type_custom")), flg2=Container(screen_off=False, longrange=False, bt5phy=False, adv_flags=True, adv_crypto=False, smiley=uEnumIntegerString.new(0, "smiley_off")), temp_offset=0.0, temperature_unit=u"°C", humi_offset=0.0, humidity_unit=u"%", advertising_interval=2.5, adv_int_unit=u"sec.", measure_interval=4, rf_tx_power=uEnumIntegerString.new(169, "RF_POWER_Positive_0p04_dBm"), connect_latency=1.0, connect_latency_unit=u"sec.", min_step_time_update_lcd=2.45, min_s_t_upd_lcd_unit=u"sec.", hw_cfg=Container(sensor=uEnumIntegerString.new(0, "sensor_SHT4x"), reserved=0, hwver=uEnumIntegerString.new(4, "hwver_LYWSD03MMC_B1_6")), averaging_measurements=180)
 ```
 
 To pretty print its content:
@@ -515,17 +527,17 @@ Container:
         adv_crypto = False
         smiley = (enum) smiley_off 0
     temp_offset = 0.0
-    temperature_unit = u'°C' (total 2)
+    temperature_unit = u"°C" (total 2)
     humi_offset = 0.0
-    humidity_unit = u'%' (total 1)
+    humidity_unit = u"%" (total 1)
     advertising_interval = 2.5
-    adv_int_unit = u'sec.' (total 4)
+    adv_int_unit = u"sec." (total 4)
     measure_interval = 4
     rf_tx_power = (enum) RF_POWER_Positive_0p04_dBm 169
     connect_latency = 1.0
-    connect_latency_unit = u'sec.' (total 4)
+    connect_latency_unit = u"sec." (total 4)
     min_step_time_update_lcd = 2.45
-    min_s_t_upd_lcd_unit = u'sec.' (total 4)
+    min_s_t_upd_lcd_unit = u"sec." (total 4)
     hw_cfg = Container:
         sensor = (enum) sensor_SHT4x 0
         reserved = 0
@@ -612,19 +624,52 @@ Full example to update a byte sequence, setting a single value:
 ```python
 from atc_mi_interface import cfg
 
-CFG_BYTES = '43 85 10 00 00 28 04 A9 31 31 04 B4'  # initial byte sequence
+CFG_BYTES = "43 85 10 00 00 28 04 A9 31 31 04 B4"  # initial byte sequence
 
 cfg_constr = cfg.parse(bytes.fromhex(CFG_BYTES))  # first we create its "construct"
 cfg_constr.flg.tx_measures = True  # then we update the value
 new_cfg_bytes = cfg.build(cfg_constr)  # subsequently, we build the new byte sequence
 
-print(new_cfg_bytes.hex(' ').upper())
+print(new_cfg_bytes.hex(" ").upper())
 ```
 
 Output:
 
 ```
 43 C5 10 00 00 28 04 A9 31 31 04 B4
+```
+
+## Running the Packet Log Inspector Shell
+
+Press the "Open Python Shell" button to run the Packet Log Inspector Shell.
+
+Accessing the parsed structure:
+
+```python
+cfg_data = frame.main_panel.construct_hex_editor.construct_editor._model.root_obj
+contextkw = frame.main_panel.construct_hex_editor.contextkw
+frame.main_panel.construct_hex_editor.binary
+```
+
+To read a specific value, use the following examples:
+
+```python
+cfg_data.custom_format[0].temperature
+cfg_data.bt_home_v2_format[0].data_point.payload[0].data.battery_level
+```
+
+Assign the variable to change it:
+
+```python
+cfg_data.custom_enc_format[0].codec.temperature = 18.5
+cfg_data.bt_home_v2_format[0].data_point.payload[1].data.temperature = 19.2
+```
+
+Build the new bytes and update the UI:
+
+```python
+from atc_mi_interface import bt_home_v2_format
+frame.main_panel.construct_hex_editor.binary = bt_home_v2_format.build(cfg_data.bt_home_v2_format[0], **contextkw)
 ```
 
 ## Processing BLE advertisements
@@ -792,7 +837,7 @@ async def main(address):
                     for char in service.characteristics:
                         name_bytes = await client.read_gatt_char(char)
                         if char.handle in valid_bytes_characteristics:
-                            print(char.handle, service.description, "-", char.description, "- Value:", name_bytes.hex(' '))
+                            print(char.handle, service.description, "-", char.description, "- Value:", name_bytes.hex(" "))
                         if char.handle in valid_string_characteristics:
                             print(char.handle, service.description, "-", char.description, ":", name_bytes.decode())
                         if char.handle == native_temp_hum_v_char:
@@ -825,11 +870,11 @@ With native LYWSD03MMC firmware, its output is:
 53 Temperature and Humidity : Container:
     version = 1
     temperature = 19.1
-    temperature_unit = u'°C' (total 2)
+    temperature_unit = u"°C" (total 2)
     humidity = 47
-    humidity_unit = u'%' (total 1)
+    humidity_unit = u"%" (total 1)
     battery_v = 2.983
-    battery_v_unit = u'V' (total 1)
+    battery_v_unit = u"V" (total 1)
 57 Unknown - Batt - Value: 64
 66 comfortable temp and humi : Container:
     version = 1
@@ -837,7 +882,7 @@ With native LYWSD03MMC firmware, its output is:
     temperature_low = 19.0
     humidity_high = 85
     humidity_low = 20
-    humidity_unit = u'%' (total 1)
+    humidity_unit = u"%" (total 1)
 95 Xiaomi Inc. - Version : 1.0.0_0130
 ```
 
@@ -933,7 +978,7 @@ python3 -m atc_mi_interface.atc_mi_config -m A4:C1:38:AA:BB:CC -c
 # Printing the date as well as time delta adjustment
 python3 -m atc_mi_interface.atc_mi_config -m A4:C1:38:AA:BB:CC -d
 
-# Setting the device date to the host system's date
+# Setting the device date to the host system"s date
 python3 -m atc_mi_interface.atc_mi_config -m A4:C1:38:AA:BB:CC -Dd
 
 # Setting the time delta adjustment to DELTA = -30
@@ -960,7 +1005,7 @@ python3 -m atc_mi_interface.atc_mi_config -m A4:C1:38:AA:BB:CC -E "Internal conf
 # Set advertising mode to "mi_like"
 python3 -m atc_mi_interface.atc_mi_config -m A4:C1:38:AA:BB:CC -E "Internal configuration|flg|advertising_type = 2"
 
-# Set advertising mode to "bt_home"
+# Set advertising mode to "bt_home" (depending on the firmware release of the thermometer, it can be bt_home version 1 or, with v4.5 or higher, bt_home_v2)
 python3 -m atc_mi_interface.atc_mi_config -m A4:C1:38:AA:BB:CC -E "Internal configuration|flg|advertising_type = 3"
 ```
 
@@ -1037,7 +1082,7 @@ For example, the following code prints all returned commands and "binary" values
 for key, item in data_dict.items():
     if "binary" in item:
         decoded_data = item["construct"].parse(item["binary"])
-        print("Command", hex(key), "=", item["binary"].hex(' ').upper())
+        print("Command", hex(key), "=", item["binary"].hex(" ").upper())
         print("Decoded data:", decoded_data)
 ```
 
@@ -1061,7 +1106,7 @@ from atc_mi_interface import normalize_report
 
 configuration = argparse.Namespace()  # all attributes need to be initialized
 
-configuration.address = 'A4:C1:38:AA:BB:CC'  # Set to the actual MAC address of the device
+configuration.address = "A4:C1:38:AA:BB:CC"  # Set to the actual MAC address of the device
 configuration.info = False  # True to return the device information
 configuration.chars = False  # True to return the device characteristics (configuration)
 configuration.gui = False  # True to edit the device configuration using the GUI. [It should be set to False with API]
@@ -1086,7 +1131,7 @@ print("Return code (False, None, True):", ret)
 for key, item in data_dict.items():
     if "binary" in item:
         decoded_data = item["construct"].parse(item["binary"])
-        print("Command", hex(key), "=", item["binary"].hex(' ').upper())
+        print("Command", hex(key), "=", item["binary"].hex(" ").upper())
         print("Decoded data:", normalize_report(str(decoded_data)))
         print()
 
@@ -1101,14 +1146,14 @@ As mentioned, a queried command can return more byte sequences, like `configurat
 Command 0x10 = 08 CC BB AA 38 C1 A4 9D 52
 Decoded data: Container:
     length = 8
-    MAC = 'A4:C1:38:AA:BB:CC' (total 17)
-    mac_vendor = 'Telink Semiconductor (Taipei) Co'... (truncated, total 38)
+    MAC = "A4:C1:38:AA:BB:CC" (total 17)
+    mac_vendor = "Telink Semiconductor (Taipei) Co"... (truncated, total 38)
     hex RandMAC digits = 21149
 
 Command 0x11 = 00 62 6C 74 2E 33 2E 31 32 39 76 4F 61 77 45 31 47 41 54 43
 Decoded data: Container:
-    null byte = b'\x00' (total 1)
-    name = 'blt.3.129vOawE1GATC' (total 19)
+    null byte = b"\x00" (total 1)
+    name = "blt.3.129vOawE1GATC" (total 19)
 
 Command 0x12 = 72 C9 2E 9E D6 21 3F 76 33 76 57 7F 2F 15 18 51 0D 8A 8D 43 3F C5 C6 32 51 16 C8 DA
 Decoded data: Container:
@@ -1126,7 +1171,7 @@ On the other hand, `configuration.string = "0x60"` (corresponding to `python3 -m
 
 ```
 Command 0x60 = 60 DB B6 B6 27 1D D3
-Decoded data: 0000   60 DB B6 B6 27 1D D3                              `...'..
+Decoded data: 0000   60 DB B6 B6 27 1D D3                              `..."..
 ```
 
 `configuration.edit_list`, when valued, requires a list of lists of strings, where each element is a `EDIT_LIST` string assignment, like described before. The sequence of `EDIT_LIST` assignments can be added in any format, regardless it is included in the outer list, or in the nested one, or in both. To assign a null list (i.e., `-E` option without arguments): `configuration.edit_list = [[]]`.
@@ -1135,7 +1180,7 @@ Decoded data: 0000   60 DB B6 B6 27 1D D3                              `...'..
 
 Set `configuration.chars = True` in the previous program to print all the thermometer settings.
 
-Alternatively, the following program can be used to query the thermometer for command '0x55' (CMD_ID_CFG, Get/set custom firmware internal configuration):
+Alternatively, the following program can be used to query the thermometer for command "0x55" (CMD_ID_CFG, Get/set custom firmware internal configuration):
 
 ```python
 import asyncio
@@ -1143,12 +1188,12 @@ from bleak import BleakClient
 from atc_mi_interface import cfg, normalize_report
 
 characteristic_uuid = "00001f1f-0000-1000-8000-00805f9b34fb"  # Characteristic UUID 0x1F1F
-command_to_read = b'\x55'  # use 'cfg' to decode this command
+command_to_read = b"\x55"  # use "cfg" to decode this command
 mac_address = "A4:C1:38:AA:BB:CC"  # change this with the device MAC address
 
 async def main(address):
     def notification_handler(handle: int, data: bytes) -> None:
-        print(handle, data.hex(' ').upper())
+        print(handle, data.hex(" ").upper())
         if bytes([data[0]]) == command_to_read:
             print(normalize_report(str(cfg.parse(data[1:]))))
 
@@ -1195,17 +1240,17 @@ Container:
         adv_crypto = False
         smiley = (enum) smiley_off 0
     temp_offset = 0.0
-    temperature_unit = '°C' (total 2)
+    temperature_unit = "°C" (total 2)
     humi_offset = 0.0
-    humidity_unit = '%' (total 1)
+    humidity_unit = "%" (total 1)
     advertising_interval = 2.5
-    adv_int_unit = 'sec.' (total 4)
+    adv_int_unit = "sec." (total 4)
     measure_interval = 4
     rf_tx_power = (enum) RF_POWER_Positive_0p04_dBm 169
     connect_latency = 1.0
-    connect_latency_unit = 'sec.' (total 4)
+    connect_latency_unit = "sec." (total 4)
     min_step_time_update_lcd = 2.45
-    min_s_t_upd_lcd_unit = 'sec.' (total 4)
+    min_s_t_upd_lcd_unit = "sec." (total 4)
     hw_cfg:
         sensor = (enum) sensor_SHT4x 0
         reserved = 0
@@ -1213,11 +1258,11 @@ Container:
     averaging_measurements = 180
 ```
 
-Within the output, the obtained bytes '55 43 85 10 00 00 28 04 A9 31 31 04 B4 00' can be decoded with the following code:
+Within the output, the obtained bytes "55 43 85 10 00 00 28 04 A9 31 31 04 B4 00" can be decoded with the following code:
 
 ```python
 from atc_mi_interface import cfg, normalize_report
-data = '55 43 85 10 00 00 28 04 A9 31 31 04 B4 00'
+data = "55 43 85 10 00 00 28 04 A9 31 31 04 B4 00"
 print(normalize_report(str(cfg.parse(bytes.fromhex(data)[1:]))))
 ```
 
@@ -1226,13 +1271,13 @@ To only change some specific parameters from a predefined settings, first obtain
 ```python
 from atc_mi_interface import cfg, normalize_report
 
-data = '55 43 85 10 00 00 28 04 A9 31 31 04 B4 00'  # settings
+data = "55 43 85 10 00 00 28 04 A9 31 31 04 B4 00"  # settings
 
 cfg_data = cfg.parse(bytes.fromhex(data)[1:])  # obtain the *construct* form from the settings
 cfg_data.temp_offset = 1.2                     # perform the assignment
 new_data = cfg.build(cfg_data)                 # build the new settings
 
-print(new_data.hex(' '))
+print(new_data.hex(" "))
 print(normalize_report(str(cfg.parse(new_data))))
 ```
 
@@ -1244,7 +1289,7 @@ from bleak import BleakClient
 from atc_mi_interface import cfg
 
 characteristic_uuid = "00001f1f-0000-1000-8000-00805f9b34fb"  # Characteristic UUID 0x1F1F
-command_to_set = b'\x55'  # use 'cfg' to decode this command
+command_to_set = b"\x55"  # use "cfg" to decode this command
 mac_address = "A4:C1:38:AA:BB:CC"  # change this with the device MAC address
 temp_offset_value = 1.2
 
@@ -1252,7 +1297,7 @@ async def main(address):
     data_out = []
 
     def notification_handler(handle: int, data: bytes) -> None:
-        print("Notifying", handle, data.hex(' ').upper())
+        print("Notifying", handle, data.hex(" ").upper())
         data_out.append(data)  # store the parameter (settings)
 
     for times in range(20):
@@ -1268,11 +1313,11 @@ async def main(address):
                 await asyncio.sleep(0.1)  # data_out should include the initial settings
                 for data in data_out:
                     if bytes([data[0]]) == command_to_set:
-                        print("Initial settings:", data.hex(' '))
+                        print("Initial settings:", data.hex(" "))
                         cfg_data = cfg.parse(data[1:])  # obtain the *construct* form
                         cfg_data.temp_offset = temp_offset_value  # perform the assignment
                         new_char = command_to_set + cfg.build(cfg_data)[1:]  # build the new settings removing the initial byte (version ID) and adding the command (command_to_set)
-                        print("New settings:", new_char.hex(' '))
+                        print("New settings:", new_char.hex(" "))
                         await client.write_gatt_char(  # store the new settings
                             characteristic_uuid, new_char, response=True)
                         break
@@ -1297,7 +1342,7 @@ from atc_mi_interface.atc_mi_config import atc_mi_configuration
 configuration = argparse.Namespace()  # all attributes need to be initialized
 
 configuration.edit_list = [["Internal configuration|temp_offset = 1.2"]]  # actual setting
-configuration.address = 'A4:C1:38:AA:BB:CC'  # Set to the actual MAC address of the device
+configuration.address = "A4:C1:38:AA:BB:CC"  # Set to the actual MAC address of the device
 configuration.info = False  # True to return the device information
 configuration.chars = False  # True to return the device characteristics (configuration)
 configuration.gui = False  # True to edit the device configuration using the GUI. [It should be set to False with API]
@@ -1319,7 +1364,7 @@ ret, data_dict, data_out = asyncio.run(atc_mi_configuration(configuration))
 print("Return code (False, None, True):", ret)
 for key, item in data_dict.items():
     if "binary" in item:
-        print("Command", hex(key), "=", item["binary"].hex(' ').upper())
+        print("Command", hex(key), "=", item["binary"].hex(" ").upper())
 for item in data_out:
     for key, value in item.items():
         print("Entity name:", key, "- Value:", *value)
@@ -1336,10 +1381,11 @@ The [atc_mi_construct.py](atc_mi_interface/atc_mi_construct.py) module allows ma
 ```mermaid
 classDiagram
     BtHomeCodec --|> Tunnel
+    BtHomeV2Codec --|> BtHomeCodec
     MiLikeCodec --|> BtHomeCodec
     AtcMiCodec --|> BtHomeCodec
 
-    class AtcMiCodec{
+    class BtHomeV2Codec{
         _decode()
         _encode()
     }
@@ -1349,10 +1395,14 @@ classDiagram
         _encode()
     }
 
+    class AtcMiCodec{
+        _decode()
+        _encode()
+    }
+
     class BtHomeCodec{
         def_mac
         default_bindkey
-        size_payload
 
         __init__()
         _decode()

--- a/python-interface/atc_mi_interface/__version__.py
+++ b/python-interface/atc_mi_interface/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.0"  # Format: A.B.C.postN
+__version__ = "2.0.0"  # Format: A.B.C.postN

--- a/python-interface/atc_mi_interface/atc_mi_adv_format.py
+++ b/python-interface/atc_mi_interface/atc_mi_adv_format.py
@@ -33,6 +33,11 @@ gatt_dict = {
         "gatt": '0000181e-0000-1000-8000-00805f9b34fb',
         "length": None,
         "header": bytes.fromhex("161e18"),
+    },
+    "bt_home_v2": {
+        "gatt": '0000fcd2-0000-1000-8000-00805f9b34fb',
+        "length": None,
+        "header": bytes.fromhex("16d2fc"),
     }
 }
 

--- a/python-interface/atc_mi_interface/atc_mi_config.py
+++ b/python-interface/atc_mi_interface/atc_mi_config.py
@@ -363,6 +363,7 @@ def gui_edit(editing_structure: dict, args: argparse.Namespace):
         sys.exit(2)
 
     custom.add_custom_tunnel(BtHomeCodec, "BtHomeCodec")
+    custom.add_custom_tunnel(BtHomeV2Codec, "BtHomeV2Codec")
     custom.add_custom_tunnel(AtcMiCodec, "AtcMiCodec")
     custom.add_custom_tunnel(MiLikeCodec, "MiLikeCodec")
     custom.add_custom_adapter(

--- a/python-interface/atc_mi_interface/atc_mi_construct_adapters.py
+++ b/python-interface/atc_mi_interface/atc_mi_construct_adapters.py
@@ -15,10 +15,9 @@ MacVendor = Switch(
 
 
 class BtHomeCodec(Tunnel):
-    def __init__(self, subcon, size_payload, bindkey=b'', mac_address=b''):
+    def __init__(self, subcon, bindkey=b'', mac_address=b''):
         super().__init__(subcon)
         self.default_bindkey = bindkey
-        self.size_payload = size_payload
         self.def_mac = mac_address
 
     def bindkey(self, ctx):
@@ -33,23 +32,25 @@ class BtHomeCodec(Tunnel):
         except Exception:
             return self.def_mac
 
-    def decrypt(self, ctx, nonce, encrypted_data, mic):
+    def decrypt(self, ctx, nonce, encrypted_data, mic, update):
         bindkey = self.bindkey(ctx)
         if not bindkey:
             raise ValueError('Missing bindkey during decrypt().')
         cipher = AES.new(bindkey, AES.MODE_CCM, nonce=nonce, mac_len=4)
-        cipher.update(b"\x11")
+        if update is not None:
+            cipher.update(update)
         try:
             return cipher.decrypt_and_verify(encrypted_data, mic), None
         except Exception as e:
             return None, "Decryption error: " + str(e)
 
-    def encrypt(self, ctx, nonce, msg):
+    def encrypt(self, ctx, nonce, msg, update):
         bindkey = self.bindkey(ctx)
         if not bindkey:
             raise ValueError('Missing bindkey during encrypt().')
         cipher = AES.new(bindkey, AES.MODE_CCM, nonce=nonce, mac_len=4)
-        cipher.update(b"\x11")
+        if update is not None:
+            cipher.update(update)
         return cipher.encrypt_and_digest(msg)
 
     def _decode(self, obj, ctx, path):
@@ -62,7 +63,9 @@ class BtHomeCodec(Tunnel):
         count_id = pkt[-8:-4]  # Int32ul
         mic = pkt[-4:]
         nonce = mac + uuid + count_id
-        msg, error = self.decrypt(ctx, nonce, encrypted_data, mic)
+        msg, error = self.decrypt(
+            ctx, nonce, encrypted_data, mic, update=b"\x11"
+        )
         if error:
             return error
         return count_id + msg
@@ -71,11 +74,45 @@ class BtHomeCodec(Tunnel):
         mac = self.mac(ctx)
         if not mac:
             raise ValueError('Missing MAC address during _encode().')
-        count_id = bytes(obj)[:4]  # Int32ul
+        length_count_id = 4  # first 4 bytes = 32 bits
+        count_id = bytes(obj)[:length_count_id]  # Int32ul
         uuid16 = b"\x1e\x18"
         nonce = mac + uuid16 + count_id
         ciphertext, mic = self.encrypt(
-            ctx, nonce, bytes(obj)[4:self.size_payload + 4])
+            ctx, nonce, obj[length_count_id:], update=b"\x11"
+        )
+        return ciphertext + count_id + mic
+
+
+class BtHomeV2Codec(BtHomeCodec):
+    def _decode(self, obj, ctx, path):
+        mac = self.mac(ctx)
+        if not mac:
+            raise ValueError('Missing MAC address during _decode().')
+        pkt = ctx._io.getvalue()[2:]
+        uuid = pkt[0:2]
+        device_info = pkt[2:3]
+        encrypted_data = pkt[3:-8]
+        count_id = pkt[-8:-4]  # Int32ul
+        mic = pkt[-4:]
+        nonce = mac + uuid + device_info + count_id
+        msg, error = self.decrypt(ctx, nonce, encrypted_data, mic, update=None)
+        if error:
+            return error
+        return count_id + msg
+
+    def _encode(self, obj, ctx, path):
+        mac = self.mac(ctx)
+        if not mac:
+            raise ValueError('Missing MAC address during _encode().')
+        length_count_id = 4  # first 4 bytes = 32 bits
+        count_id = bytes(obj)[:length_count_id]  # Int32ul
+        uuid16 = b"\xd2\xfc"
+        device_info = b"\x41"
+        nonce = mac + uuid16 + device_info + count_id
+        ciphertext, mic = self.encrypt(
+            ctx, nonce, bytes(obj)[length_count_id:], update=None,
+        )
         return ciphertext + count_id + mic
 
 
@@ -88,11 +125,13 @@ class AtcMiCodec(BtHomeCodec):
         cipherpayload = payload[:-4]
         header_bytes = ctx._io.getvalue()[:4]  # b'\x0e\x16\x1a\x18' (custom_enc) or b'\x0b\x16\x1a\x18' (atc1441_enc)
         nonce = mac[::-1] + header_bytes + bytes(obj)[:1]
-        token = payload[-4:] #mic
-        msg, error = self.decrypt(ctx, nonce, cipherpayload, token)
+        mic = payload[-4:]
+        msg, error = self.decrypt(
+            ctx, nonce, cipherpayload, mic, update=b"\x11"
+        )
         if error:
             return error
-        return msg + bytes(len(obj) - len(msg))
+        return msg
 
     def _encode(self, obj, ctx, path):
         mac = self.mac(ctx)
@@ -100,8 +139,7 @@ class AtcMiCodec(BtHomeCodec):
             raise ValueError('Missing MAC address during _encode().')
         header_bytes = ctx._io.getvalue()[:4] + b'\xbd'  # b'\x0e\x16\x1a\x18\xbd' (custom_enc) or b'\x0b\x16\x1a\x18\xbd' (atc1441_enc)
         nonce = mac[::-1] + header_bytes
-        ciphertext, mic = self.encrypt(
-            ctx, nonce, bytes(obj)[:self.size_payload])
+        ciphertext, mic = self.encrypt(ctx, nonce, obj, update=b"\x11")
         return b'\xbd' + ciphertext + mic
 
 
@@ -115,8 +153,10 @@ class MiLikeCodec(BtHomeCodec):
         cnt = ctx._io.getvalue()[8:9]  # encode frame cnt
         count_id = payload[-7:-4]  # Int24ul
         nonce = mac[::-1] + dev_id + cnt + count_id
-        token = payload[-4:] #mic
-        msg, error = self.decrypt(ctx, nonce, cipherpayload, token)
+        mic = payload[-4:]
+        msg, error = self.decrypt(
+            ctx, nonce, cipherpayload, mic, update=b"\x11"
+        )
         if error:
             return error
         return count_id + msg
@@ -126,10 +166,12 @@ class MiLikeCodec(BtHomeCodec):
         mac = self.mac(ctx)
         dev_id = ctx._io.getvalue()[6:8]  # pid, PRODUCT_ID
         cnt = ctx._io.getvalue()[8:9]  # encode frame cnt
-        count_id = bytes(obj)[:3]  # Int24ul
+        length_count_id = 3  # first 3 bytes = 24 bits
+        count_id = bytes(obj)[:length_count_id]  # Int24ul
         nonce = mac[::-1] + dev_id + cnt + count_id
         ciphertext, mic = self.encrypt(
-            ctx, nonce, bytes(obj)[3:self.size_payload + 3])
+            ctx, nonce, obj[length_count_id:], update=b"\x11"
+        )
         return ciphertext + count_id + mic
 
 
@@ -145,8 +187,12 @@ Int16ub_x1000 = ExprAdapter(Int16ub,
         obj_ / 1000, lambda obj, ctx: int(float(obj) * 1000))
 Int16ul_x1000 = ExprAdapter(Int16ul,
         obj_ / 1000, lambda obj, ctx: int(float(obj) * 1000))
+Int24ul_x1000 = ExprAdapter(Int24ul,
+        obj_ / 1000, lambda obj, ctx: int(float(obj) * 1000))
 Int16ul_x100 = ExprAdapter(
     Int16ul, obj_ / 100, lambda obj, ctx: int(float(obj) * 100))
+Int24ul_x100 = ExprAdapter(
+    Int24ul, obj_ / 100, lambda obj, ctx: int(float(obj) * 100))
 Int16sl_x100 = ExprAdapter(
     Int16sl, obj_ / 100, lambda obj, ctx: int(float(obj) * 100))
 Int16ub_x10 = ExprAdapter(
@@ -159,7 +205,6 @@ Int16sl_x10 = ExprAdapter(
     Int16sl, obj_ / 10, lambda obj, ctx: int(float(obj) * 10))
 
 def normalize_report(report):
-    #import pdb;pdb.set_trace()
     report = re.sub(r"\n\s*Container:\n?", "\n", report, flags=re.DOTALL)
     report = re.sub(r"\n\s*version =[^\n]*\n", "\n", report, flags=re.DOTALL)
     report = re.sub(r" = Container:\s*\n", ":\n", report, flags=re.DOTALL)

--- a/python-interface/atc_mi_interface/atc_mi_format_test.py
+++ b/python-interface/atc_mi_interface/atc_mi_format_test.py
@@ -10,57 +10,16 @@ import construct_editor.core.custom as custom
 from collections import OrderedDict
 
 from . import atc_mi_construct
+from .construct_module import *  # It includes setting the gallery_descriptor dictionary.
 
-custom.add_custom_tunnel(atc_mi_construct.BtHomeCodec, "BtHomeCodec")
-custom.add_custom_tunnel(atc_mi_construct.AtcMiCodec, "AtcMiCodec")
-custom.add_custom_tunnel(atc_mi_construct.MiLikeCodec, "MiLikeCodec")
-custom.add_custom_adapter(
-    atc_mi_construct.ExprAdapter,
-    "ComputedValue",
-    custom.AdapterObjEditorType.String)
-custom.add_custom_adapter(
-    atc_mi_construct.ReversedMacAddress,
-    "ReversedMacAddress",
-    custom.AdapterObjEditorType.String)
-custom.add_custom_adapter(
-    atc_mi_construct.MacAddress,
-    "MacAddress",
-    custom.AdapterObjEditorType.String)
 
 def main():
     app = wx.App(False)
     frame = wx.Frame(None, title="ATC MI Formats", size=(1000, 500))
 
-    gallery_descriptor = {
-        "general_format": GalleryItem(
-            construct=atc_mi_construct.general_format,
-        ),
-        "custom_format": GalleryItem(
-            construct=atc_mi_construct.custom_format,
-        ),
-        "custom_enc_format": GalleryItem(
-            construct=atc_mi_construct.custom_enc_format,
-        ),
-        "mi_like_format": GalleryItem(
-            construct=atc_mi_construct.mi_like_format,
-        ),
-        "atc1441_format": GalleryItem(
-            construct=atc_mi_construct.atc1441_format,
-        ),
-        "atc1441_enc_format": GalleryItem(
-            construct=atc_mi_construct.atc1441_enc_format,
-        ),
-        "bt_home_format": GalleryItem(
-            construct=atc_mi_construct.bt_home_format,
-        ),
-        "bt_home_enc_format": GalleryItem(
-            construct=atc_mi_construct.bt_home_enc_format,
-        ),
-    }
-
     ordered_samples = OrderedDict(
     # ordered_samples OrderedDict for the overall data, independent of the
-    # previous gallery_descriptor. Notice that if a reference is used "mac_address",
+    # gallery_descriptor. Notice that if a reference is used "mac_address",
     # reference_label and key_label must be set in ConstructGallery
         [
             (
@@ -93,41 +52,6 @@ def main():
                 {
                     "binary": bytes.fromhex(
                         "0b 16 1a 18 bd e9 b7 5d b8 56 f3 03"),
-                    "mac_address": "A4:C1:38:AA:BB:CC",
-                },
-            ),
-            (
-                "bt_home (temp, humidity, batt%)",
-                {
-                    "binary": bytes.fromhex(
-                        "11 16 1c 18 02 00 56 23 02 6c 07 03 03 ff 13 02 01 "
-                        "4e"),
-                    "mac_address": "A4:C1:38:AA:BB:CC",
-                },
-            ),
-            (
-                "bt_home (batt v)",
-                {
-                    "binary": bytes.fromhex(
-                        "0d 16 1c 18 02 00 63 02 10 01 03 0c d9 0a"),
-                    "mac_address": "A4:C1:38:AA:BB:CC",
-                },
-            ),
-            (
-                "bt_home_enc (temp, humidity, batt%)",
-                {
-                    "binary": bytes.fromhex(
-                        "16 16 1e 18 83 93 db a2 55 4c d8 04 be ab 78 cf b3 00 "
-                        "00 7d 6a 1c d2"),
-                    "mac_address": "A4:C1:38:AA:BB:CC",
-                },
-            ),
-            (
-                "bt_home_enc (batt v)",
-                {
-                    "binary": bytes.fromhex(
-                        "12 16 1e 18 12 79 94 44 eb 3a 3f e4 b3 00 00 59 62 3a "
-                        "29"),
                     "mac_address": "A4:C1:38:AA:BB:CC",
                 },
             ),
@@ -176,6 +100,78 @@ def main():
                     "mac_address": "A4:C1:38:AA:BB:CC",
                 },
             ),
+            (
+                "bt_home v1 (temp, humidity, batt%)",
+                {
+                    "binary": bytes.fromhex(
+                        "11 16 1c 18 02 00 56 23 02 6c 07 03 03 ff 13 02 01 "
+                        "4e"),
+                    "mac_address": "A4:C1:38:AA:BB:CC",
+                },
+            ),
+            (
+                "bt_home v1 (batt v, switch)",
+                {
+                    "binary": bytes.fromhex(
+                        "0d 16 1c 18 02 00 63 02 10 01 03 0c d9 0a"),
+                    "mac_address": "A4:C1:38:AA:BB:CC",
+                },
+            ),
+            (
+                "bt_home_enc v1 (temp, humidity, batt%)",
+                {
+                    "binary": bytes.fromhex(
+                        "16 16 1e 18 83 93 db a2 55 4c d8 04 be ab 78 cf b3 00 "
+                        "00 7d 6a 1c d2"),
+                    "mac_address": "A4:C1:38:AA:BB:CC",
+                },
+            ),
+            (
+                "bt_home_enc v1 (batt v, switch)",
+                {
+                    "binary": bytes.fromhex(
+                        "12 16 1e 18 12 79 94 44 eb 3a 3f e4 b3 00 00 59 62 3a "
+                        "29"),
+                    "mac_address": "A4:C1:38:AA:BB:CC",
+                },
+            ),
+            (
+                "bt_home_v2 (temp, humidity, batt%)",
+                {
+                    "binary": bytes.fromhex(
+                        "0e 16 d2 fc 40 00 d6 01 50 02 80 07 03 8a 13"
+                    ),
+                    "mac_address": "A4:C1:38:AA:BB:CC",
+                },
+            ),
+            (
+                "bt_home_v2 (batt v, switch)",
+                {
+                    "binary": bytes.fromhex(
+                        "0b 16 d2 fc 40 00 d9 0c d1 0a 10 00"
+                    ),
+                    "mac_address": "A4:C1:38:AA:BB:CC",
+                },
+            ),
+            (
+                "bt_home_v2_enc (temp, humidity, batt%)",
+                {
+                    "binary": bytes.fromhex(
+                        "14 16 d2 fc 41 95 b0 ef da 78 9d d9 53 b0 26 00 00 "
+                        "93 41 62 6f"
+                    ),
+                    "mac_address": "A4:C1:38:AA:BB:CC",
+                },
+            ),
+            (
+                "bt_home_v2_enc (batt v, switch)",
+                {
+                    "binary": bytes.fromhex(
+                        "11 16 d2 fc 41 d4 6c c8 e7 74 b9 26 00 00 cb d8 4a 40"
+                    ),
+                    "mac_address": "A4:C1:38:AA:BB:CC",
+                },
+            ),
         ]
     )
 
@@ -184,7 +180,7 @@ def main():
     }
 
 
-    ConstructGallery(frame,
+    frame.main_panel = ConstructGallery(frame,
         gallery_descriptor=gallery_descriptor,
         ordered_samples=ordered_samples,
         ref_key_descriptor=ref_key_descriptor,

--- a/python-interface/atc_mi_interface/construct_module.py
+++ b/python-interface/atc_mi_interface/construct_module.py
@@ -14,6 +14,7 @@ reload(atc_mi_construct)
 
 # Set custom adapters in construct_editor
 custom.add_custom_tunnel(atc_mi_construct.BtHomeCodec, "BtHomeCodec")
+custom.add_custom_tunnel(atc_mi_construct.BtHomeV2Codec, "BtHomeV2Codec")
 custom.add_custom_tunnel(atc_mi_construct.AtcMiCodec, "AtcMiCodec")
 custom.add_custom_tunnel(atc_mi_construct.MiLikeCodec, "MiLikeCodec")
 custom.add_custom_adapter(
@@ -54,5 +55,8 @@ gallery_descriptor = {
     ),
     "bt_home_enc_format": GalleryItem(
         construct=atc_mi_construct.bt_home_enc_format,
+    ),
+    "bt_home_v2_format": GalleryItem(
+        construct=atc_mi_construct.bt_home_v2_format,
     ),
 }


### PR DESCRIPTION
# atc_mi_interface v2.0.0

- Add support of BTHome v2 advertisements
- Support of BTHome v2 clear and encrypted advertising types
- Revised codecs, removing the `size_payload` parameter
- Revised documentation
- Revised `.gitignore` to exclude *pypi* build directories

resolves https://github.com/pvvx/ATC_MiThermometer/issues/404
