### PR TITLE
Adjust battery percentage calculation to avoid integer rounding and overflowing.

### DIFF
--- a/src/battery.c
+++ b/src/battery.c
@@ -88,8 +88,8 @@ _attribute_ram_code_
 uint8_t get_battery_level(uint16_t battery_mv) {
 	uint8_t battery_level = 0;
 	if (battery_mv > MIN_VBAT_MV) {
-		battery_level = (battery_mv - MIN_VBAT_MV) / ((MAX_VBAT_MV
-				- MIN_VBAT_MV) / 100);
+		battery_level = ((battery_mv - MIN_VBAT_MV) * 100) /
+						(MAX_VBAT_MV - MIN_VBAT_MV);
 		if (battery_level > 100)
 			battery_level = 100;
 	}

--- a/src/battery.c
+++ b/src/battery.c
@@ -89,7 +89,7 @@ uint8_t get_battery_level(uint16_t battery_mv) {
 	uint8_t battery_level = 0;
 	if (battery_mv > MIN_VBAT_MV) {
 		battery_level = ((battery_mv - MIN_VBAT_MV) * 100) /
-						(MAX_VBAT_MV - MIN_VBAT_MV);
+				(MAX_VBAT_MV - MIN_VBAT_MV);
 		if (battery_level > 100)
 			battery_level = 100;
 	}


### PR DESCRIPTION
I am testing some LIR2032 batteries, which have a higher full capacity, around 4.02V (4020mV) [nominal ~3.7V], and as a result, I am running into an overflow.  In looking into this, there is also a rounding error which is minor, which was causing some precision loss.

There were two choices to resolve this, the first is to remove the rounding error, which I chose here, so that instead of (max-min)/100 getting rounded from 7.5 to 7, we just multiply the other side by 100 instead and keep it integer based until the end.  This fix should allow it to work correctly (relatively) with voltages up to around 4112mV.  This issue was causing the battery percentage (which is obviously relative) to be incorrect by up to 7% and overflowing at around 3985mV.

The other option, should 4112mV not be enough would be to change the `battery_level` to `uint16_t` until the calculation is complete and then cast it back to `uint8_t` at the return.

Obviously this isn't a full solution to change the calculation based on different nominal voltages, but it will keep the rechargeable batteries from showing really low values when full before crossing back under the overflow and reporting 100%.