### PR TITLE
Avoid integer precsion loss in denominator of battery calculation

### DIFF
--- a/src/battery.c
+++ b/src/battery.c
@@ -88,8 +88,8 @@ _attribute_ram_code_
 uint8_t get_battery_level(uint16_t battery_mv) {
 	uint8_t battery_level = 0;
 	if (battery_mv > MIN_VBAT_MV) {
-		battery_level = (battery_mv - MIN_VBAT_MV) / ((MAX_VBAT_MV
-				- MIN_VBAT_MV) / 100);
+		battery_level = ((battery_mv - MIN_VBAT_MV) * 2) / ((MAX_VBAT_MV
+				- MIN_VBAT_MV) / 50);
 		if (battery_level > 100)
 			battery_level = 100;
 	}


### PR DESCRIPTION
Avoid integer precision loss in denominator of battery calculation while remaining within uint16_t size constraints.

This keeps the entire calculation within uint16_t constraints while not causing an integer rounding in the denominator.

Fixes #524 

Feel free to reject this if you feel this is too hacky, as I understand it makes it less clear at the expense of being more technically correct.