### PR TITLE
Fix checksum of devbis2ble image

### DIFF
--- a/zigbee_ota/devbis2ble.json
+++ b/zigbee_ota/devbis2ble.json
@@ -4,7 +4,7 @@
         "fileSize": 86786,
         "manufacturerCode": 56085,
         "imageType": 515,
-        "sha512": "cdf7675681eedd00b79fd647ea30f89e187986a7b48b3cd12829c41725c7340218dca21a25fb48c86aa015eed7344b1c29880e0bfe969e57b7237755de05ed6e",
+        "sha512": "bd6a6b818f3cf670972a774fe6313bd8502cdde9cf717002ba429ff85d958d11ff69b415c875bf91fd76a4e3a96f7ba82750e9d69b62ffb17da4d6a1dbeab133",
         "url": "https://github.com/pvvx/ATC_MiThermometer/raw/master/zigbee_ota/db15-0203-99993001-ATC_v53.zigbee"
     }
 ]


### PR DESCRIPTION
I used the `zigbee_ota/devbis2ble.json` index to convert my LYWSD03MMC sensor back to ble, so I could convert it to zigbee again with a different firmware (ZigbeeTLc).

I used the following ZHA config:

```
zha:
  enable_quirks: true
  custom_quirks_path: /config/custom_zha_quirks/
  zigpy_config:
    ota:
      enabled: true
      extra_providers:
        - type: z2m
          url: https://raw.githubusercontent.com/pvvx/ATC_MiThermometer/refs/heads/master/zigbee_ota/devbis2ble.json
```

But I found errors in the debug logging of zigpy that the checksum didn't match. I checked locally and it seems to be a bug in the file? This PR just fixes the checksum.

Since I'm documenting what I did anyway, and I could not find exact documentation on the web, here's some steps if somebody else would be in the same situation that I was: you want to go from devbis (I had a blank screen issue), back to BLE, so you can re-flash:

### ZHA setup

If this PR is merged, just use the above config in your configuration.yaml If this PR is not merged yet, or if you just want to use a 'local' index, here's how:

1. `mkdir /root/config/ota`
2. `cd /root/config/ota`
3. wget https://raw.githubusercontent.com/jgrgt/ATC_MiThermometer/refs/heads/devbis2ble-checksum-fix/zigbee_ota/devbis2ble.json
4. `mv devbis2ble.json index.json` (probably not needed, but I was getting desparate :)
5. (At this point I edited the file, but since you downloaded my file this should no longer be needed?)
6. Edit your `/root/config/configuration.yaml` file to add the local file:
   ```
zha:
  enable_quirks: true
  custom_quirks_path: /config/custom_zha_quirks/
  zigpy_config:
    ota:
      enabled: true
      extra_providers:
        - type: z2m_local
          index_file: ./ota/index.json
   ```

### HA restart and triggering the OTA update

1. Restart HA, do a full restart
2. For good measure, you can add zha-toolkit, and execute this action through the developer tools:
```
data:
  ieee: <firmware entity of your sensor>
action: zha_toolkit.ota_notify
```
3. The firmware update should show up on the ZHA page of your sensor.
