### PR TITLE
Increase advertisement interval to 60s, use unsigned int 16

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -429,8 +429,8 @@ void test_config(void) {
 		wrk.tx_measures = 0xff; // always notify
 	if (cfg.advertising_interval == 0) // 0 ?
 		cfg.advertising_interval = 1; // 1*62.5 = 62.5 ms
-	else if (cfg.advertising_interval > 160) // max 160 : 160*62.5 = 10000 ms
-		cfg.advertising_interval = 160; // 160*62.5 = 10000 ms
+	else if (cfg.advertising_interval > 960) // max 960 : 960*62.5 = 60000 ms
+		cfg.advertising_interval = 960; // 960*62.5 = 60000 ms
 	wrk.adv_interval_delay = cfg.flg3.adv_interval_delay;
 	wrk.adv_interval = cfg.advertising_interval * 100; // Tadv_interval = adv_interval * 62.5 ms , adv_interval in 0.625 ms
 
@@ -469,7 +469,10 @@ void test_config(void) {
 		wrk.connection_timeout = 100;	//x10 ms,  1 sec
 
 	if (!cfg.connect_latency) {
-		my_periConnParameters.intervalMin =	(cfg.advertising_interval * 625	/ 30) - 1; // Tmin = 20*1.25 = 25 ms, Tmax = 3333*1.25 = 4166.25 ms
+		// @TODO: add more precise min-max range checks
+		// The connection interval can range from 7.5ms to 4.0s
+		// 160 is used for  backward compatibility
+		my_periConnParameters.intervalMin = ( min(160, cfg.advertising_interval) * 625 / 30) - 1; // Tmin = 20*1.25 = 25 ms, Tmax = 3333*1.25 = 4166.25 ms
 		my_periConnParameters.intervalMax = my_periConnParameters.intervalMin + 5;
 		my_periConnParameters.latency = 0;
 	} else {

--- a/src/app.h
+++ b/src/app.h
@@ -126,7 +126,7 @@ typedef struct __attribute__((packed)) _cfg_t {
 	} flg3;
 	u8 event_adv_cnt;		// min value = 5
 #endif
-	u8 advertising_interval; // multiply by 62.5 for value in ms (1..160,  62.5 ms .. 10 sec)
+	u16 advertising_interval; // multiply by 62.5 for value in ms (1..160,  62.5 ms .. 60 sec)
 	u8 measure_interval; // measure_interval = advertising_interval * x (2..25)
 	u8 rf_tx_power; // RF_POWER_N25p18dBm .. RF_POWER_P3p01dBm (130..191)
 	u8 connect_latency; // +1 x0.02 sec ( = connection interval), Tmin = 1*20 = 20 ms, Tmax = 256 * 20 = 5120 ms


### PR DESCRIPTION
The change helps to reduce number of pulses and, as the result, prolong battery lifespan.

According to measurements in [topic](https://github.com/pvvx/ATC_MiThermometer/discussions/663#discussioncomment-13972252) for MJWSD06MMC with default settings:
* 0.01331mA(avg) * 5000ms =  66.55 uC
* pulse burst if use chart = ~16 uC.
* sleep mode only 66.55-16= ~50.5 uC for 5s
* 16/66.55 = 24% is used for the burst for default settings. For max 10s ~13.7%. If increase interval to 60s, it would be 16/(50.5*12+16)=~2.6%


I realize it might be issues with connection and data collection without understanding how the change can impact a setup. The change just gives possibility. In case of connection issues, button press can be used too.
Real case scenario with LE Long Range and 1 hour periodic data collection https://github.com/pvvx/ATC_MiThermometer/discussions/463#discussioncomment-14097570.
I don't collect remotely data at all, use as a plain room temp sensor and time after time connect to review average data. I don't need 10s advertisements.

The change will also require UI Flasher modifications to support 2 bytes for adv. field and remove 10000 restriction in js logic. 
Ideally, advanced user should be able to use intervals in range 0(disable) - DeviceBTStackLimit(unit16?).

