### PR TITLE
Add adaptive connectionless time sync via BTHome beacon scanning

### DIFF
--- a/src/app_config.h
+++ b/src/app_config.h
@@ -715,6 +715,7 @@ extern "C" {
 		| SERVICE_HARD_CLOCK \
 		| SERVICE_TH_TRG \
 		| SERVICE_MI_KEYS \
+		| SERVICE_SCANTIM \
 )
 
 #define MI_HW_VER_FADDR 0x7D000 // Mi HW version

--- a/src/scanning.c
+++ b/src/scanning.c
@@ -16,6 +16,9 @@
 #include "flash_eep.h"
 #include "scanning.h"
 #include "bthome_beacon.h"
+#if (DEV_SERVICES & SERVICE_HARD_CLOCK)
+#include "rtc.h"
+#endif
 #if SCAN_USE_BINDKEY
 #include "ccm.h"
 #endif
@@ -26,6 +29,10 @@
 #if !(DEV_SERVICES & SERVICE_RDS)
 #error "This feature will not work unless 'SERVICE_RDS' is set!"
 #endif
+
+// Maximum allowed drift before next sync (seconds).
+// Adaptive algorithm targets: next_interval = SCAN_MAX_DRIFT_SEC * current_interval / measured_drift
+#define SCAN_MAX_DRIFT_SEC	30
 
 #define SCAN_ADV_INTERVAL	ADV_INTERVAL_505MS
 #define SCAN_ADV_COUNT	3
@@ -128,7 +135,25 @@ void filter_bthome_ad(padv_bthome_t p, u8 * pmac) {
 		while(len > 0) {
 			if(ps->type < sizeof(tblBTHome)) {
 				if(ps->type == BtHomeID_timestamp) { // in 1 sec
-					wrk.utc_time_sec = ps->data_uw; // + scan.cfg.localt;
+					u32 new_time = ps->data_uw;
+					s32 drift = (s32)(new_time - wrk.utc_time_sec);
+					if(drift < 0) drift = -drift;
+					wrk.utc_time_sec = new_time;
+#if (DEV_SERVICES & SERVICE_HARD_CLOCK)
+					rtc_set_utime(wrk.utc_time_sec);
+#endif
+					// Adaptive interval: skip first sync (initial drift is meaningless)
+					if(scan.sync_count > 0 && drift > 0) {
+						u32 new_interval = (SCAN_MAX_DRIFT_SEC * scan.cfg.interval) / (u32)drift;
+						if(new_interval < 1800) new_interval = 1800;      // min 30 min
+						if(new_interval > 1296000) new_interval = 1296000; // max 15 days
+						scan.cfg.interval = new_interval;
+					}
+					scan.fail_count = 0;
+					if(scan.sync_count < 255) scan.sync_count++;
+					// Shrink scan window after 3 consecutive successes (floor 50ms)
+					if(scan.sync_count >= 3 && scan.window_ms > 50)
+						scan.window_ms /= 2;
 #if 0 //(DEV_SERVICES & SERVICE_SCREEN)
 				} else if(ps->type == BtHomeID_raw) { // Show ext. small and big number
 					size = ps->data_ub[0];
@@ -194,25 +219,30 @@ int scanning_event_callback(u32 h, u8 *p, int n) {
 		if ((h & 0xff) == HCI_EVT_LE_META) {
 			//----- hci le event: le adv report event -----
 			if (p[0] == HCI_SUB_EVT_LE_ADVERTISING_REPORT) { // ADV packet
-				//after controller is set to scan state, it will report all the adv packet it received by this event
 				event_adv_report_t *pa = (event_adv_report_t *) p;
-				if(memcmp(scan.cfg.MAC, pa->mac, sizeof(scan.cfg.MAC)) == 0) {
-					blc_ll_setScanEnable(BLC_SCAN_DISABLE, DUP_FILTER_DISABLE); // отсановить сканирование
-					scan.start_tik = 0; // разрешить sleep
+				// MAC filter: all-zero accepts any, otherwise match configured MAC
+				u8 mac_any = 1;
+				int k;
+				for(k = 0; k < sizeof(scan.cfg.MAC); k++) {
+					if(scan.cfg.MAC[k] != 0) { mac_any = 0; break; }
+				}
+				if(mac_any || memcmp(scan.cfg.MAC, pa->mac, sizeof(scan.cfg.MAC)) == 0) {
 					u32 adlen = pa->len;
 					u8 rssi = pa->data[adlen];
-					if (adlen && adlen < 32 && rssi != 0) { // rssi != 0
+					if (adlen && adlen < 32 && rssi != 0) {
 						u32 i = 0;
 						while(adlen) {
 							pad_uuid16_t pd = (pad_uuid16_t) &pa->data[i];
 							u32 len = pd->size + 1;
 							if(len <= adlen) {
 								if(len >= sizeof(ad_uuid16_t) && pd->type == GAP_ADTYPE_SERVICE_DATA_UUID_16BIT) {
-									if((pd->uuid16) == ADV_BTHOME_UUID16) { // GATT Service: BTHome v2
+									if((pd->uuid16) == ADV_BTHOME_UUID16) {
 										memcpy(prev_advs, pd, len);
 										filter_bthome_ad((adv_bthome_t *)prev_advs, pa->mac);
-										blta.adv_duraton_en = 0; // reload adv
-										scan_stop(); // stop scan
+										blc_ll_setScanEnable(BLC_SCAN_DISABLE, DUP_FILTER_DISABLE);
+										scan.start_tik = 0;
+										blta.adv_duraton_en = 0;
+										scan_stop();
 									}
 								}
 							} else
@@ -252,8 +282,12 @@ void scan_wakeup(void) {
 //////////////////////////////////////////////////////////
 void scan_init(void) {
 
-	if(flash_read_cfg(&scan.cfg, EEP_ID_SCN, sizeof(scan.cfg)) != sizeof(scan.cfg))
+	if(flash_read_cfg(&scan.cfg, EEP_ID_SCN, sizeof(scan.cfg)) != sizeof(scan.cfg)) {
 		memset(&scan.cfg, 0, sizeof(scan.cfg));
+		scan.cfg.interval = 3600; // default: scan every hour
+	}
+	if(scan.cfg.interval == 0)
+		scan.cfg.interval = 3600; // ensure scan is enabled
 #if SCAN_DEBUG
 	// Test values:
 	scan.cfg.interval = 30; // 30 sec for test
@@ -264,7 +298,8 @@ void scan_init(void) {
 	scan.cfg.MAC[4] = 0x05;
 	scan.cfg.MAC[5] = 0x06;
 #endif
-	scan_stop();
+	scan.start_time = 0;    // trigger immediate first scan on boot
+	scan.window_ms = 1800;  // initial window: guaranteed catch (~1.58s beacon)
 }
 
 //////////////////////////////////////////////////////////
@@ -304,7 +339,15 @@ _attribute_ram_code_
 __attribute__((optimize("-Os")))
 void scan_task(void) {
 	u32 tt = clock_time() - scan.start_tik;
-	if(tt > 9*CLOCK_16M_SYS_TIMER_CLK_1MS) {
+	if(tt > scan.window_ms * CLOCK_16M_SYS_TIMER_CLK_1MS) {
+		// Scan window expired without catching beacon
+		if(scan.fail_count < 255) scan.fail_count++;
+		scan.sync_count = 0;
+		// Spring-back: widen window (cap 1800ms) + increase frequency (floor 1800s)
+		if(scan.window_ms < 1800)
+			scan.window_ms = (scan.window_ms * 2 > 1800) ? 1800 : scan.window_ms * 2;
+		if(scan.cfg.interval > 1800)
+			scan.cfg.interval /= 2;
 		blc_ll_setScanEnable(BLC_SCAN_DISABLE, DUP_FILTER_DISABLE); // остановить сканирование
 		scan.start_tik = 0;
 #ifdef SET_NO_SLEEP_MODE

--- a/src/scanning.h
+++ b/src/scanning.h
@@ -24,6 +24,9 @@ typedef struct {
 	u32	start_time;		// = wrk.utc_time_sec при старте каждого интервала
 	scan_cfg_t cfg;
 	u8 	enabled;
+	u8	sync_count;		// consecutive successful syncs (adaptive window)
+	u8	fail_count;		// consecutive scan misses (spring-back)
+	u16	window_ms;		// current scan window in ms (adaptive: 50..1800)
 } scan_wrk_t;
 
 extern scan_wrk_t scan;


### PR DESCRIPTION
## Summary

Enable automatic time synchronization for ATC thermometers via BTHome beacon scanning, without requiring a BLE connection or button press. Tested on MJWSD05MMC.

Related issues: #656, #56

## Changes

**`src/app_config.h`**
- Enable `SERVICE_SCANTIM` for MJWSD05MMC

**`src/scanning.h`**
- Add `sync_count`, `fail_count`, `window_ms` fields to `scan_wrk_t` for adaptive algorithm

**`src/scanning.c`**
- Add `SCAN_MAX_DRIFT_SEC` constant (default 30s, configurable)
- MAC filter: when scan MAC is all-zero (unconfigured), accept any BTHome time beacon; when configured, only accept that specific MAC
- Only stop scanning after BTHome UUID match, not on arbitrary BLE packets
- Sync external RTC on `SERVICE_HARD_CLOCK` devices: MJWSD05MMC has an external PCF85163 RTC that periodically overwrites `wrk.utc_time_sec` (in `app.c:1184`). Without also calling `rtc_set_utime()`, the RTC would write back the old time after a successful scan sync. Original scan code didn't need this because LYWSD03MMC (the only device with `SERVICE_SCANTIM`) has no external RTC.
- Default scan interval 3600s when unconfigured, immediate scan on boot
- Adaptive scan interval: `next_interval = SCAN_MAX_DRIFT_SEC × current_interval / drift` (range: 30min ~ 15 days). First sync only calibrates time (initial drift has no reference value)
- Adaptive scan window with spring-back mechanism:
  - Initial: 1800ms (guaranteed catch with ~1.58s beacon interval)
  - After 3 consecutive successes: halve window (floor 50ms)
  - On scan failure: double window (cap 1800ms) + halve interval (floor 1800s)

## How it works

1. A Home Assistant integration ([ha-atc-time-sync](https://github.com/chinaboard/ha-atc-time-sync)) broadcasts a BTHome v2 beacon containing `BtHomeID_timestamp (0x50)` with current local time
2. The thermometer periodically scans for this beacon and updates its clock
3. The scan interval and window self-tune based on observed drift

## Limitations

- Scanning requires `BT5+ PHY` to be **disabled** in device settings. Extended Advertising (`ext_adv_init != EXT_ADV_Off`) and scan mode are mutually exclusive per the existing check in `app.c:1240`. This is a runtime config (`cfg.flg2.bt5phy`), not a compile-time limitation — `SERVICE_LE_LR` can remain enabled.

## Simulation results (1 year, RF RX 6mA CR2032 = 100mAh per #656)

| Crystal | Drift/day | Steady interval | Max drift | Syncs/yr | Energy/yr |
|---------|-----------|----------------|-----------|----------|-----------|
| 20ppm | 1.7s | 15.0 days | 26s | 26 | 0.20 mAh |
| 30ppm | 2.6s | 11.6 days | 30s | 34 | 0.24 mAh |
| 50ppm | 4.3s | 6.9 days | 30s | 56 | 0.41 mAh |
| 100ppm | 8.6s | 3.5 days | 30s | 109 | 0.81 mAh |
| 700ppm | 60.5s | 0.5 days | 30s | 755 | 5.74 mAh |

## Test plan

- [x] Build for MJWSD05MMC (`make build POJECT_DEF='-DDEVICE_TYPE=9'`)
- [x] Flash via OTA, confirm time syncs on first boot
- [x] Verify adaptive interval converges after second sync
- [ ] Long-term monitoring (days/weeks)