### PR TITLE
Battery %: replace linear mV mapping with CR2450 discharge-curve fit

### DIFF
--- a/src/battery.c
+++ b/src/battery.c
@@ -91,20 +91,54 @@ u16 get_adc_mv(u32 p_ain) { // ADC_InputPchTypeDef
 	return (adc_average * ADC_BAT_VREF_MV) >> 12; // adc_vref default: 1175 (mV)
 }
 
-#define VBAT2LEVEL_SHL		(32-8) // max level = 256
-#define VBAT2LEVEL_COEF	    ((100 << VBAT2LEVEL_SHL)/(MAX_VBAT_MV - MIN_VBAT_MV))
+#if !USE_NI_ZN_BATTERY
+// Remaining battery capacity vs. voltage: a piecewise-linear fit of the
+// Energizer CR2450 datasheet typical discharge curve (7.5 kΩ continuous
+// load, 21°C): https://data.energizer.com/pdfs/cr2450.pdf
+// The curve's normalized shape is set by the Li/MnO₂ chemistry, not the cell
+// size, so the same table serves CR2032/CR2477 devices too.
+//
+// Entries are remaining charge in 0.1% units at 50 mV steps, from
+// MIN_VBAT_MV (0%) to MAX_VBAT_MV (100%). Entries must be non-decreasing;
+// the interpolation below assumes it. If MIN_VBAT_MV or MAX_VBAT_MV change,
+// re-sample the datasheet curve at each step to rebuild the table.
+#define VBAT2LEVEL_STEP_MV	50
+static const u16 vbat2level_lut[] = {
+	0, 6, 13, 22, 34, 49, 67, 91, 124, 160, 202, 257, 340, 465, 634, 821, 1000
+};
+STATIC_ASSERT_INT_DIV(MAX_VBAT_MV - MIN_VBAT_MV, VBAT2LEVEL_STEP_MV);
+STATIC_ASSERT(sizeof(vbat2level_lut) / sizeof(vbat2level_lut[0])
+	== (MAX_VBAT_MV - MIN_VBAT_MV) / VBAT2LEVEL_STEP_MV + 1);
+#endif // !USE_NI_ZN_BATTERY
 
-// 2200..3000 mv - 0..100%
+// MIN_VBAT_MV..MAX_VBAT_MV -> 0..1000 (0.1% units)
 _attribute_ram_code_
-u8 get_battery_level(u16 battery_mv) {
-	u8 battery_level = 100;
+u16 get_battery_level_x10(u16 battery_mv) {
+	u16 battery_level_x10 = 1000;
 	if (battery_mv < MAX_VBAT_MV) {
 		if (battery_mv > MIN_VBAT_MV) {
-			battery_level = (u8)((u32)((((u32)battery_mv - (u32)MIN_VBAT_MV)
-				* (u32)VBAT2LEVEL_COEF) >> VBAT2LEVEL_SHL));
+#if USE_NI_ZN_BATTERY
+			// no discharge-curve data for Ni-Zn: linear map, rounded to nearest
+			battery_level_x10 = (u16)((((u32)(battery_mv - MIN_VBAT_MV) * 1000)
+				+ (MAX_VBAT_MV - MIN_VBAT_MV) / 2) / (MAX_VBAT_MV - MIN_VBAT_MV));
+#else
+			u16 d = battery_mv - MIN_VBAT_MV;
+			u16 i = d / VBAT2LEVEL_STEP_MV;
+			u16 f = d - i * VBAT2LEVEL_STEP_MV; // d % step without a second divide
+			u16 lo = vbat2level_lut[i];
+			u16 hi = vbat2level_lut[i + 1];
+			battery_level_x10 = lo + (u16)(((u32)(hi - lo) * f
+				+ VBAT2LEVEL_STEP_MV / 2) / VBAT2LEVEL_STEP_MV);
+#endif
 		} else {
-			battery_level = 0;
+			battery_level_x10 = 0;
 		}
 	}
-	return battery_level;
+	return battery_level_x10;
+}
+
+// MIN_VBAT_MV..MAX_VBAT_MV -> 0..100%
+_attribute_ram_code_
+u8 get_battery_level(u16 battery_mv) {
+	return (u8)((get_battery_level_x10(battery_mv) + 5) / 10);
 }

--- a/src/battery.h
+++ b/src/battery.h
@@ -23,5 +23,6 @@ extern u32 adc_average;
 #define get_battery_mv() get_adc_mv(SHL_ADC_VBAT)	// Channel B0P/B5P
 
 u8 get_battery_level(u16 battery_mv);
+u16 get_battery_level_x10(u16 battery_mv);	// 0..1000, 0.1% units
 
 #endif // _BATTERY_H_

--- a/src/epd_cgg1.c
+++ b/src/epd_cgg1.c
@@ -326,10 +326,10 @@ void show_batt_cgg1(void) {
 	u16 battery_level = 0;
 #if USE_AVERAGE_BATTERY
 	if (measured_data.average_battery_mv > MIN_VBAT_MV) {
-		battery_level = ((measured_data.average_battery_mv - MIN_VBAT_MV)*10)/((MAX_VBAT_MV - MIN_VBAT_MV)/100);
+		battery_level = get_battery_level_x10(measured_data.average_battery_mv);
 #else
 	if (measured_data.battery_mv > MIN_VBAT_MV) {
-			battery_level = ((measured_data.battery_mv - MIN_VBAT_MV)*10)/((MAX_VBAT_MV - MIN_VBAT_MV)/100);
+			battery_level = get_battery_level_x10(measured_data.battery_mv);
 #endif
 		if (battery_level > 995)
 			battery_level = 995;

--- a/src/epd_cgg1n.c
+++ b/src/epd_cgg1n.c
@@ -292,7 +292,7 @@ _attribute_ram_code_ __attribute__((optimize("-Os"))) void show_small_number_x10
 void show_batt_cgg1(void) {
 	u16 battery_level = 0;
 	if (measured_data.battery_mv > MIN_VBAT_MV) {
-		battery_level = ((measured_data.battery_mv - MIN_VBAT_MV)*10)/((MAX_VBAT_MV - MIN_VBAT_MV)/100);
+		battery_level = get_battery_level_x10(measured_data.battery_mv);
 		if (battery_level > 995)
 			battery_level = 995;
 	}

--- a/src/lcd_cgdk2.c
+++ b/src/lcd_cgdk2.c
@@ -363,10 +363,10 @@ void show_batt_cgdk2(void) {
 	u16 battery_level = 0;
 #if USE_AVERAGE_BATTERY
 	if (measured_data.average_battery_mv > MIN_VBAT_MV) {
-		battery_level = ((measured_data.average_battery_mv - MIN_VBAT_MV)*10)/((MAX_VBAT_MV - MIN_VBAT_MV)/100);
+		battery_level = get_battery_level_x10(measured_data.average_battery_mv);
 #else
 	if (measured_data.battery_mv > MIN_VBAT_MV) {
-		battery_level = ((measured_data.battery_mv - MIN_VBAT_MV)*10)/((MAX_VBAT_MV - MIN_VBAT_MV)/100);
+		battery_level = get_battery_level_x10(measured_data.battery_mv);
 #endif
 		if (battery_level > 995)
 			battery_level = 995;


### PR DESCRIPTION
get_battery_level() mapped millivolts linearly between MIN_VBAT_MV and MAX_VBAT_MV, which badly overstates mid-life charge for Li/MnO2 coin cells (2800 mV read as 75% when ~34% of capacity remains). Replace it with a 17-knot piecewise-linear table digitized from the Energizer CR2450 datasheet typical discharge curve (7.5 kOhm continuous load, 21 C), charge-normalized so MIN_VBAT_MV -> 0% and MAX_VBAT_MV -> 100%. The normalized curve shape is chemistry-determined, so the same table serves CR2032/CR2477 devices.

A new get_battery_level_x10() returns 0.1% units and becomes the single conversion path; the CGG1/CGG1N/CGDK2 displays previously duplicated the linear formula inline and now share it. The Ni-Zn test build keeps a linear map, rescaled to 0.1% units (the old fixed-point macro trick would overflow at the x10 scale: 1000 << 24 exceeds int32).

Behavior notes: whole-percent output now rounds to nearest instead of truncating, and 100% is reported from ~2999 mV because the curve is flat near full charge.